### PR TITLE
containerdstore: Initial push support

### DIFF
--- a/daemon/containerdstore/prune.go
+++ b/daemon/containerdstore/prune.go
@@ -1,0 +1,98 @@
+package containerdstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/content"
+	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// TODO: handle pruneFilters
+func (cs *containerdStore) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
+	is := cs.client.ImageService()
+	store := cs.client.ContentStore()
+
+	images, err := is.List(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to list images")
+	}
+
+	platform := platforms.DefaultStrict()
+	report := types.ImagesPruneReport{}
+	toDelete := map[digest.Digest]uint64{}
+	errs := []error{}
+
+	for _, img := range images {
+		err := getContentDigestsWithSizes(ctx, img, store, platform, toDelete)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		err = is.Delete(ctx, img.Name, containerdimages.SynchronousDelete())
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		report.ImagesDeleted = append(report.ImagesDeleted,
+			types.ImageDeleteResponseItem{
+				Untagged: img.Name,
+			},
+		)
+	}
+
+	for digest, size := range toDelete {
+		err := store.Delete(ctx, digest)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "Failed to delete %s", digest.String()))
+		}
+		report.SpaceReclaimed += size
+		report.ImagesDeleted = append(report.ImagesDeleted,
+			types.ImageDeleteResponseItem{
+				Deleted: digest.String(),
+			},
+		)
+	}
+
+	if len(errs) > 1 {
+		return &report, MultipleErrors{all: errs}
+	} else if len(errs) == 1 {
+		return &report, errs[0]
+	}
+
+	return &report, nil
+}
+
+func getContentDigestsWithSizes(ctx context.Context, img containerdimages.Image, store content.Store, platform platforms.MatchComparer, toDelete map[digest.Digest]uint64) error {
+	return containerdimages.Walk(ctx, containerdimages.Handlers(containerdimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if desc.Size < 0 {
+			return nil, fmt.Errorf("invalid size %v in %v (%v)", desc.Size, desc.Digest, desc.MediaType)
+		}
+		toDelete[desc.Digest] = uint64(desc.Size)
+		return nil, nil
+	}), containerdimages.LimitManifests(containerdimages.FilterPlatforms(containerdimages.ChildrenHandler(store), platform), platform, 1)), img.Target)
+}
+
+type MultipleErrors struct {
+	all []error
+}
+
+func (m MultipleErrors) Error() string {
+	errString := ""
+	for _, err := range m.all {
+		if len(m.all) > 0 {
+			errString += "\n"
+		}
+		errString += err.Error()
+	}
+
+	return errString
+}

--- a/daemon/containerdstore/service.go
+++ b/daemon/containerdstore/service.go
@@ -377,10 +377,6 @@ func (cs *containerdStore) ImageHistory(ctx context.Context, name string) ([]*im
 	panic("not implemented")
 }
 
-func (cs *containerdStore) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
-	panic("not implemented")
-}
-
 func (cs *containerdStore) ImportImage(ctx context.Context, src string, repository string, platform *ocispec.Platform, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error {
 	panic("not implemented")
 }


### PR DESCRIPTION
kNote: With the current containerd's pull behaviour the object that get
tagged as the pulled tag is not an image manifest but manifest list.
This means that doing:
```
docker pull docker.io/library/ubuntu:latest
docker tag docker.io/library/ubuntu:latest newrepo/ubuntu:latest
docker push newrepo/ubuntu:latest
```

Will result in an error, because the pull downloads only the default
platform and the newrepo/ubuntu:latest is a manifest list that
references all original image's platforms - and those cannot be pushed
to a remote because the pusher doesn't have them.

This will will work in case of single-platform manifest lists or if you
pull the manifest list along with all the platforms via ctr:
```
ctr --address /run/docker/containerd/containerd.sock -n moby \
    image pull --all-platforms docker.io/library/ubuntu:latest
docker push newrepo/ubuntu:latest
```

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

