### PR TITLE
daemon: WithCommonOptions(): fix root initialisation

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -733,10 +733,6 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 				Readonly: c.HostConfig.ReadonlyRootfs,
 			}
 		}
-		s.Root = &specs.Root{
-			Path:     c.BaseFS.Path(),
-			Readonly: c.HostConfig.ReadonlyRootfs,
-		}
 		if err := c.SetupWorkingDirectory(daemon.idMapping.RootPair()); err != nil {
 			return err
 		}


### PR DESCRIPTION
This probably was a bad rebase in "Introduce containerd-snapshotter feature flag"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

