### PR TITLE
compute container's layer size 

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -49,7 +49,7 @@ type stateBackend interface {
 // monitorBackend includes functions to implement to provide containers monitoring functionality.
 type monitorBackend interface {
 	ContainerChanges(name string) ([]archive.Change, error)
-	ContainerInspect(name string, size bool, version string) (interface{}, error)
+	ContainerInspect(ctx context.Context, name string, size bool, version string) (interface{}, error)
 	ContainerLogs(ctx context.Context, name string, config *types.ContainerLogsOptions) (msgs <-chan *backend.LogMessage, tty bool, err error)
 	ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error
 	ContainerTop(name string, psArgs string) (*container.ContainerTopOKBody, error)

--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -12,7 +12,7 @@ func (s *containerRouter) getContainersByName(ctx context.Context, w http.Respon
 	displaySize := httputils.BoolValue(r, "size")
 
 	version := httputils.VersionFromContext(ctx)
-	json, err := s.backend.ContainerInspect(vars["name"], displaySize, version)
+	json, err := s.backend.ContainerInspect(ctx, vars["name"], displaySize, version)
 	if err != nil {
 		return err
 	}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -43,7 +43,7 @@ type Backend interface {
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
-	ContainerInspectCurrent(name string, size bool) (*types.ContainerJSON, error)
+	ContainerInspectCurrent(ctx context.Context, name string, size bool) (*types.ContainerJSON, error)
 	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	ContainerRm(name string, config *types.ContainerRmConfig) error
 	ContainerKill(name string, sig string) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -356,7 +356,7 @@ func (c *containerAdapter) start(ctx context.Context) error {
 }
 
 func (c *containerAdapter) inspect(ctx context.Context) (types.ContainerJSON, error) {
-	cs, err := c.backend.ContainerInspectCurrent(c.container.name(), false)
+	cs, err := c.backend.ContainerInspectCurrent(ctx, c.container.name(), false)
 	if ctx.Err() != nil {
 		return types.ContainerJSON{}, ctx.Err()
 	}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -624,8 +624,46 @@ func (cs *containerdStore) LayerStoreStatus() [][2]string {
 	return [][2]string{}
 }
 
-func (cs *containerdStore) GetContainerLayerSize(containerID string) (int64, int64) {
-	panic("not implemented")
+func (cs *containerdStore) GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error) {
+	snapshotter := cs.client.SnapshotService(containerd.DefaultSnapshotter)
+	sizeCache := make(map[digest.Digest]int64)
+	snapshotSizeFn := func(d digest.Digest) (int64, error) {
+		if s, ok := sizeCache[d]; ok {
+			return s, nil
+		}
+		usage, err := snapshotter.Usage(ctx, d.String())
+		if err != nil {
+			return 0, err
+		}
+		sizeCache[d] = usage.Size
+		return usage.Size, nil
+	}
+
+	c, err := cs.client.ContainerService().Get(ctx, containerID)
+	if err != nil {
+		return 0, 0, err
+	}
+	image, err := cs.client.GetImage(ctx, c.Image)
+	if err != nil {
+		return 0, 0, err
+	}
+	diffIDs, err := image.RootFS(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	chainIDs := identity.ChainIDs(diffIDs)
+
+	usage, err := snapshotter.Usage(ctx, containerID)
+	if err != nil {
+		return 0, 0, err
+	}
+	size := usage.Size
+
+	virtualSize, err := computeVirtualSize(chainIDs, snapshotSizeFn)
+	if err != nil {
+		return 0, 0, err
+	}
+	return size, size + virtualSize, nil
 }
 
 func (cs *containerdStore) UpdateConfig(maxDownloads, maxUploads int) {

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -54,7 +54,7 @@ type ImageService interface {
 	GetLayerMountID(cid string) (string, error)
 	ReleaseLayer(rwlayer layer.RWLayer) error
 	LayerDiskUsage(ctx context.Context) (int64, error)
-	GetContainerLayerSize(containerID string) (int64, int64)
+	GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error)
 
 	// Windows specific
 

--- a/daemon/images/image_unix.go
+++ b/daemon/images/image_unix.go
@@ -4,6 +4,8 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
+
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/sirupsen/logrus"
@@ -16,7 +18,7 @@ func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) 
 }
 
 // GetContainerLayerSize returns the real size & virtual size of the container.
-func (i *ImageService) GetContainerLayerSize(containerID string) (int64, int64) {
+func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error) {
 	var (
 		sizeRw, sizeRootfs int64
 		err                error
@@ -27,7 +29,7 @@ func (i *ImageService) GetContainerLayerSize(containerID string) (int64, int64) 
 	rwlayer, err := i.layerStore.GetRWLayer(containerID)
 	if err != nil {
 		logrus.Errorf("Failed to compute size of container rootfs %v: %v", containerID, err)
-		return sizeRw, sizeRootfs
+		return sizeRw, sizeRootfs, nil
 	}
 	defer i.layerStore.ReleaseRWLayer(rwlayer)
 
@@ -46,5 +48,5 @@ func (i *ImageService) GetContainerLayerSize(containerID string) (int64, int64) 
 			sizeRootfs += sizeRw
 		}
 	}
-	return sizeRw, sizeRootfs
+	return sizeRw, sizeRootfs, nil
 }

--- a/daemon/images/image_windows.go
+++ b/daemon/images/image_windows.go
@@ -1,6 +1,8 @@
 package images
 
 import (
+	"context"
+
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/system"
@@ -8,9 +10,9 @@ import (
 )
 
 // GetContainerLayerSize returns real size & virtual size
-func (i *ImageService) GetContainerLayerSize(containerID string) (int64, int64) {
+func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error) {
 	// TODO Windows
-	return 0, 0
+	return 0, 0, nil
 }
 
 // GetLayerFolders returns the layer folders from an image RootFS

--- a/daemon/inspect_linux.go
+++ b/daemon/inspect_linux.go
@@ -1,6 +1,8 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/versions/v1p19"
@@ -19,7 +21,7 @@ func setPlatformSpecificContainerFields(container *container.Container, contJSON
 }
 
 // containerInspectPre120 gets containers for pre 1.20 APIs.
-func (daemon *Daemon) containerInspectPre120(name string) (*v1p19.ContainerJSON, error) {
+func (daemon *Daemon) containerInspectPre120(ctx context.Context, name string) (*v1p19.ContainerJSON, error) {
 	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -1,6 +1,8 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/container"
@@ -13,8 +15,8 @@ func setPlatformSpecificContainerFields(container *container.Container, contJSON
 }
 
 // containerInspectPre120 get containers for pre 1.20 APIs.
-func (daemon *Daemon) containerInspectPre120(name string) (*types.ContainerJSON, error) {
-	return daemon.ContainerInspectCurrent(name, false)
+func (daemon *Daemon) containerInspectPre120(ctx context.Context, name string) (*types.ContainerJSON, error) {
+	return daemon.ContainerInspectCurrent(ctx, name, false)
 }
 
 func inspectExecProcessConfig(e *exec.Config) *backend.ExecProcessConfig {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -234,7 +234,10 @@ func (daemon *Daemon) reducePsContainer(ctx context.Context, container *containe
 
 	// release lock because size calculation is slow
 	if filter.Size {
-		sizeRw, sizeRootFs := daemon.imageService.GetContainerLayerSize(newC.ID)
+		sizeRw, sizeRootFs, err := daemon.imageService.GetContainerLayerSize(ctx, newC.ID)
+		if err != nil {
+			return nil, err
+		}
 		newC.SizeRw = sizeRw
 		newC.SizeRootFs = sizeRootFs
 	}

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -73,9 +73,12 @@ func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.
 			if !matchLabels(pruneFilters, c.Config.Labels) {
 				continue
 			}
-			cSize, _ := daemon.imageService.GetContainerLayerSize(c.ID)
+			cSize, _, err := daemon.imageService.GetContainerLayerSize(ctx, c.ID)
+			if err != nil {
+				return nil, err
+			}
 			// TODO: sets RmLink to true?
-			err := daemon.ContainerRm(c.ID, &types.ContainerRmConfig{})
+			err = daemon.ContainerRm(c.ID, &types.ContainerRmConfig{})
 			if err != nil {
 				logrus.Warnf("failed to prune container %s: %v", c.ID, err)
 				continue


### PR DESCRIPTION
**- What I did**
implement GetContainerLayerSize using containerd snapshotter
container's RW layer (i.e active snapshot) size is available as a standard snapshotter API
container's virtual size isn't but can be computed as base image size (which we already have computation logic in place) + active snapshot size