### PR TITLE
daemon/containerd: Implement prune

### DIFF
--- a/daemon/containerd/prune.go
+++ b/daemon/containerd/prune.go
@@ -1,0 +1,95 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/content"
+	cerrdefs "github.com/containerd/containerd/errdefs"
+	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// TODO: handle pruneFilters
+func (cs *containerdStore) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
+	is := cs.client.ImageService()
+	store := cs.client.ContentStore()
+
+	images, err := is.List(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to list images")
+	}
+
+	platform := platforms.DefaultStrict()
+	report := types.ImagesPruneReport{}
+	toDelete := map[digest.Digest]uint64{}
+	errs := []error{}
+
+	for _, img := range images {
+		err := getContentDigestsWithSizes(ctx, img, store, platform, toDelete)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	for digest, size := range toDelete {
+		report.SpaceReclaimed += size
+		report.ImagesDeleted = append(report.ImagesDeleted,
+			types.ImageDeleteResponseItem{
+				Deleted: digest.String(),
+			},
+		)
+	}
+
+	for _, img := range images {
+		err = is.Delete(ctx, img.Name, containerdimages.SynchronousDelete())
+		if err != nil && !cerrdefs.IsNotFound(err) {
+			errs = append(errs, err)
+			continue
+		}
+
+		report.ImagesDeleted = append(report.ImagesDeleted,
+			types.ImageDeleteResponseItem{
+				Untagged: img.Name,
+			},
+		)
+	}
+
+	if len(errs) > 0 {
+		return &report, combineErrors(errs)
+	}
+
+	return &report, nil
+}
+
+func getContentDigestsWithSizes(ctx context.Context, img containerdimages.Image, store content.Store, platform platforms.MatchComparer, toDelete map[digest.Digest]uint64) error {
+	return containerdimages.Walk(ctx, containerdimages.Handlers(containerdimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if desc.Size < 0 {
+			return nil, fmt.Errorf("invalid size %v in %v (%v)", desc.Size, desc.Digest, desc.MediaType)
+		}
+		toDelete[desc.Digest] = uint64(desc.Size)
+		return nil, nil
+	}), containerdimages.LimitManifests(containerdimages.FilterPlatforms(containerdimages.ChildrenHandler(store), platform), platform, 1)), img.Target)
+}
+
+func combineErrors(errs []error) error {
+	if len(errs) == 1 {
+		return errs[0]
+	}
+
+	errString := ""
+	for _, err := range errs {
+		if errString != "" {
+			errString += "\n"
+		}
+		errString += err.Error()
+	}
+
+	return errors.Errorf("Multiple errors encountered:\n%s", errString)
+}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -406,10 +406,6 @@ func (cs *containerdStore) ImageHistory(name string) ([]*imagetype.HistoryRespon
 	panic("not implemented")
 }
 
-func (cs *containerdStore) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error) {
-	panic("not implemented")
-}
-
 func (cs *containerdStore) ImportImage(ctx context.Context, src string, repository string, platform *v1.Platform, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error {
 	panic("not implemented")
 }


### PR DESCRIPTION
Initial implementation for `docker image prune` that doesn't handle any filters

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

