### PR TITLE
containerd/auth: Check if registry hostname matches

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -278,7 +279,15 @@ func newResolverFromAuthConfig(authConfig *types.AuthConfig) (remotes.Resolver, 
 	opts := []docker.RegistryOpt{}
 
 	if authConfig != nil {
-		authorizer := docker.NewDockerAuthorizer(docker.WithAuthCreds(func(_ string) (string, string, error) {
+		cfgHost := registry.ConvertToHostname(authConfig.ServerAddress)
+		if cfgHost == registry.IndexHostname {
+			cfgHost = registry.DefaultRegistryHost
+		}
+		authorizer := docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {
+			if cfgHost != host {
+				logrus.WithField("host", host).WithField("cfgHost", cfgHost).Warn("Host doesn't match")
+				return "", "", nil
+			}
 			if authConfig.IdentityToken != "" {
 				return "", authConfig.IdentityToken, nil
 			}


### PR DESCRIPTION
This checks if the server that the user provided authentication for is the same as the server that we are actually authenticating with.