### PR TITLE
introduce GetImageWithDetails to manage image inspect data in backend

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -22,9 +22,9 @@ type Backend interface {
 
 type imageBackend interface {
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
-	ImageHistory(imageName string) ([]*image.HistoryResponseItem, error)
+	ImageHistory(ctx context.Context, imageName string) ([]*image.HistoryResponseItem, error)
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
-	GetImage(ctx context.Context, refOrID string, platform *specs.Platform) (*dockerimage.Image, error)
+	GetImage(ctx context.Context, refOrID string, options image.GetImageOpts) (*dockerimage.Image, error)
 	TagImage(ctx context.Context, imageName, repository, tag string) (string, error)
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)
 }

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -14,10 +14,10 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	opts "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
-	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/streamformatter"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -204,7 +204,7 @@ func (s *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, r
 }
 
 func (s *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	image, err := s.backend.GetImage(ctx, vars["name"], nil)
+	image, err := s.backend.GetImage(ctx, vars["name"], opts.GetImageOpts{Details: true})
 	if err != nil {
 		return err
 	}
@@ -230,30 +230,9 @@ func (s *imageRouter) toImageInspect(img *image.Image) (*types.ImageInspect, err
 		}
 	}
 
-	var size int64
-	var layerMetadata map[string]string
-	layerID := img.RootFS.ChainID()
-	if layerID != "" {
-		l, err := s.layerStore.Get(layerID)
-		if err != nil {
-			return nil, err
-		}
-		defer layer.ReleaseAndLog(s.layerStore, l)
-		size = l.Size()
-		layerMetadata, err = l.Metadata()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	comment := img.Comment
 	if len(comment) == 0 && len(img.History) > 0 {
 		comment = img.History[len(img.History)-1].Comment
-	}
-
-	lastUpdated, err := s.imageStore.GetLastUpdated(img.ID())
-	if err != nil {
-		return nil, err
 	}
 
 	return &types.ImageInspect{
@@ -272,15 +251,15 @@ func (s *imageRouter) toImageInspect(img *image.Image) (*types.ImageInspect, err
 		Variant:         img.Variant,
 		Os:              img.OperatingSystem(),
 		OsVersion:       img.OSVersion,
-		Size:            size,
-		VirtualSize:     size, // TODO: field unused, deprecate
+		Size:            img.Details.Size,
+		VirtualSize:     img.Details.Size, // TODO: field unused, deprecate
 		GraphDriver: types.GraphDriverData{
-			Name: s.layerStore.DriverName(),
-			Data: layerMetadata,
+			Name: img.Details.Driver,
+			Data: img.Details.Metadata,
 		},
 		RootFS: rootFSToAPIType(img.RootFS),
 		Metadata: types.ImageMetadata{
-			LastTagTime: lastUpdated,
+			LastTagTime: img.Details.LastUpdated,
 		},
 	}, nil
 }
@@ -335,7 +314,7 @@ func (s *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter, 
 
 func (s *imageRouter) getImagesHistory(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	name := vars["name"]
-	history, err := s.backend.ImageHistory(name)
+	history, err := s.backend.ImageHistory(ctx, name)
 	if err != nil {
 		return err
 	}

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -1,0 +1,9 @@
+package image
+
+import specs "github.com/opencontainers/image-spec/specs-go/v1"
+
+// GetImageOpts holds parameters to inspect an image.
+type GetImageOpts struct {
+	Platform *specs.Platform
+	Details  bool
+}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	opts "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
@@ -75,5 +76,5 @@ type VolumeBackend interface {
 type ImageBackend interface {
 	PullImage(ctx context.Context, image, tag string, platform *specs.Platform, metaHeaders map[string][]string, authConfig *types.AuthConfig, outStream io.Writer) error
 	GetRepository(context.Context, reference.Named, *types.AuthConfig) (distribution.Repository, error)
-	GetImage(ctx context.Context, refOrID string, platform *specs.Platform) (retImg *image.Image, retErr error)
+	GetImage(ctx context.Context, refOrID string, options opts.GetImageOpts) (retImg *image.Image, retErr error)
 }

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
+	imagetypes "github.com/docker/docker/api/types/image"
 	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/cluster/convert"
@@ -74,7 +75,7 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 	named, err := reference.ParseNormalizedNamed(spec.Image)
 	if err == nil {
 		if _, ok := named.(reference.Canonical); ok {
-			_, err := c.imageBackend.GetImage(ctx, spec.Image, nil)
+			_, err := c.imageBackend.GetImage(ctx, spec.Image, imagetypes.GetImageOpts{})
 			if err == nil {
 				return nil
 			}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
+	imagetypes "github.com/docker/docker/api/types/image"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/images"
@@ -76,7 +77,7 @@ func (daemon *Daemon) containerCreate(ctx context.Context, opts createOpts) (con
 	}
 
 	if opts.params.Platform == nil && opts.params.Config.Image != "" {
-		if img, _ := daemon.imageService.GetImage(ctx, opts.params.Config.Image, opts.params.Platform); img != nil {
+		if img, _ := daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform}); img != nil {
 			p := maximumSpec()
 			imgPlat := v1.Platform{
 				OS:           img.OS,
@@ -127,7 +128,7 @@ func (daemon *Daemon) create(ctx context.Context, opts createOpts) (retC *contai
 	)
 
 	if opts.params.Config.Image != "" {
-		img, err = daemon.imageService.GetImage(ctx, opts.params.Config.Image, opts.params.Platform)
+		img, err = daemon.imageService.GetImage(ctx, opts.params.Config.Image, imagetypes.GetImageOpts{Platform: opts.params.Platform})
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -40,8 +40,8 @@ type ImageService interface {
 	ImportImage(ctx context.Context, src string, repository string, platform *v1.Platform, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, changes []string) error
 	TagImage(ctx context.Context, imageName, repository, tag string) (string, error)
 	TagImageWithReference(ctx context.Context, imageID image.ID, newTag reference.Named) error
-	GetImage(ctx context.Context, refOrID string, platform *v1.Platform) (*image.Image, error)
-	ImageHistory(name string) ([]*imagetype.HistoryResponseItem, error)
+	GetImage(ctx context.Context, refOrID string, options imagetype.GetImageOpts) (*image.Image, error)
+	ImageHistory(ctx context.Context, name string) ([]*imagetype.HistoryResponseItem, error)
 	CommitImage(c backend.CommitConfig) (image.ID, error)
 	SquashImage(id, parent string) (string, error)
 

--- a/daemon/images/cache.go
+++ b/daemon/images/cache.go
@@ -3,6 +3,7 @@ package images // import "github.com/docker/docker/daemon/images"
 import (
 	"context"
 
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image/cache"
 	"github.com/sirupsen/logrus"
@@ -17,7 +18,7 @@ func (i *ImageService) MakeImageCache(ctx context.Context, sourceRefs []string) 
 	cache := cache.New(i.imageStore)
 
 	for _, ref := range sourceRefs {
-		img, err := i.GetImage(ctx, ref, nil)
+		img, err := i.GetImage(ctx, ref, imagetypes.GetImageOpts{})
 		if err != nil {
 			logrus.Warnf("Could not look up %s for cache resolution, skipping: %+v", ref, err)
 			continue

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -12,8 +12,10 @@ import (
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution/reference"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/layer"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -148,7 +150,43 @@ func (i *ImageService) manifestMatchesPlatform(img *image.Image, platform specs.
 }
 
 // GetImage returns an image corresponding to the image referred to by refOrID.
-func (i *ImageService) GetImage(ctx context.Context, refOrID string, platform *specs.Platform) (retImg *image.Image, retErr error) {
+func (i *ImageService) GetImage(ctx context.Context, refOrID string, options imagetypes.GetImageOpts) (*image.Image, error) {
+	img, err := i.getImage(refOrID, options.Platform)
+	if err != nil {
+		return nil, err
+	}
+	if options.Details {
+		var size int64
+		var layerMetadata map[string]string
+		layerID := img.RootFS.ChainID()
+		if layerID != "" {
+			l, err := i.layerStore.Get(layerID)
+			if err != nil {
+				return nil, err
+			}
+			defer layer.ReleaseAndLog(i.layerStore, l)
+			size = l.Size()
+			layerMetadata, err = l.Metadata()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		lastUpdated, err := i.imageStore.GetLastUpdated(img.ID())
+		if err != nil {
+			return nil, err
+		}
+		img.Details = &image.Details{
+			Size:        size,
+			Metadata:    layerMetadata,
+			Driver:      i.layerStore.DriverName(),
+			LastUpdated: lastUpdated,
+		}
+	}
+	return img, nil
+}
+
+func (i *ImageService) getImage(refOrID string, platform *specs.Platform) (retImg *image.Image, retErr error) {
 	defer func() {
 		if retErr != nil || retImg == nil || platform == nil {
 			return

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -167,7 +168,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 		return nil, err
 	}
 
-	img, err := i.GetImage(nil, name, platform)
+	img, err := i.GetImage(nil, name, imagetypes.GetImageOpts{Platform: platform})
 	if errdefs.IsNotFound(err) && img != nil && platform != nil {
 		imgPlat := specs.Platform{
 			OS:           img.OS,
@@ -211,7 +212,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 	}
 
 	if opts.PullOption != backend.PullOptionForcePull {
-		image, err := i.GetImage(nil, refOrID, opts.Platform)
+		image, err := i.GetImage(nil, refOrID, imagetypes.GetImageOpts{Platform: opts.Platform})
 		if err != nil && opts.PullOption == backend.PullOptionNoPull {
 			return nil, nil, err
 		}

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -63,7 +64,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 	start := time.Now()
 	records := []types.ImageDeleteResponseItem{}
 
-	img, err := i.GetImage(ctx, imageRef, nil)
+	img, err := i.GetImage(ctx, imageRef, imagetypes.GetImageOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/images/image_events.go
+++ b/daemon/images/image_events.go
@@ -2,6 +2,7 @@ package images // import "github.com/docker/docker/daemon/images"
 
 import (
 	"github.com/docker/docker/api/types/events"
+	imagetypes "github.com/docker/docker/api/types/image"
 )
 
 // LogImageEvent generates an event related to an image with only the default attributes.
@@ -11,7 +12,7 @@ func (i *ImageService) LogImageEvent(imageID, refName, action string) {
 
 // LogImageEventWithAttributes generates an event related to an image with specific given attributes.
 func (i *ImageService) LogImageEventWithAttributes(imageID, refName, action string, attributes map[string]string) {
-	img, err := i.GetImage(nil, imageID, nil)
+	img, err := i.GetImage(nil, imageID, imagetypes.GetImageOpts{})
 	if err == nil && img.Config != nil {
 		// image has not been removed yet.
 		// it could be missing if the event is `delete`.

--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -1,6 +1,7 @@
 package images // import "github.com/docker/docker/daemon/images"
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -11,9 +12,9 @@ import (
 
 // ImageHistory returns a slice of ImageHistory structures for the specified image
 // name by walking the image lineage.
-func (i *ImageService) ImageHistory(name string) ([]*image.HistoryResponseItem, error) {
+func (i *ImageService) ImageHistory(ctx context.Context, name string) ([]*image.HistoryResponseItem, error) {
 	start := time.Now()
-	img, err := i.GetImage(nil, name, nil)
+	img, err := i.GetImage(ctx, name, image.GetImageOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +70,7 @@ func (i *ImageService) ImageHistory(name string) ([]*image.HistoryResponseItem, 
 		if id == "" {
 			break
 		}
-		histImg, err = i.GetImage(nil, id.String(), nil)
+		histImg, err = i.GetImage(ctx, id.String(), image.GetImageOpts{})
 		if err != nil {
 			break
 		}

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -11,6 +11,7 @@ import (
 	dist "github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/distribution"
 	progressutils "github.com/docker/docker/distribution/utils"
 	"github.com/docker/docker/errdefs"
@@ -63,7 +64,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tag string, platfor
 		// we allow the image to have a non-matching architecture. The code
 		// below checks for this situation, and returns a warning to the client,
 		// as well as logging it to the daemon logs.
-		img, err := i.GetImage(nil, image, platform)
+		img, err := i.GetImage(ctx, image, imagetypes.GetImageOpts{Platform: platform})
 
 		// Note that this is a special case where GetImage returns both an image
 		// and an error: https://github.com/docker/docker/blob/v20.10.7/daemon/images/image.go#L175-L183

--- a/daemon/images/image_tag.go
+++ b/daemon/images/image_tag.go
@@ -4,13 +4,14 @@ import (
 	"context"
 
 	"github.com/docker/distribution/reference"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/image"
 )
 
 // TagImage creates the tag specified by newTag, pointing to the image named
 // imageName (alternatively, imageName can also be an image ID).
 func (i *ImageService) TagImage(ctx context.Context, imageName, repository, tag string) (string, error) {
-	img, err := i.GetImage(nil, imageName, nil)
+	img, err := i.GetImage(ctx, imageName, imagetypes.GetImageOpts{})
 	if err != nil {
 		return "", err
 	}

--- a/daemon/images/images.go
+++ b/daemon/images/images.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/pkg/errors"
 
 	"github.com/docker/distribution/reference"
@@ -39,7 +40,7 @@ func (i *ImageService) Map() map[image.ID]*image.Image {
 }
 
 // Images returns a filtered list of images.
-func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error) {
+func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error) {
 	if err := opts.Filters.Validate(acceptedImageFilterTags); err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([
 		err                       error
 	)
 	err = opts.Filters.WalkValues("before", func(value string) error {
-		beforeFilter, err = i.GetImage(nil, value, nil)
+		beforeFilter, err = i.GetImage(ctx, value, imagetypes.GetImageOpts{})
 		return err
 	})
 	if err != nil {
@@ -66,7 +67,7 @@ func (i *ImageService) Images(_ context.Context, opts types.ImageListOptions) ([
 	}
 
 	err = opts.Filters.WalkValues("since", func(value string) error {
-		sinceFilter, err = i.GetImage(nil, value, nil)
+		sinceFilter, err = i.GetImage(ctx, value, imagetypes.GetImageOpts{})
 		return err
 	})
 	if err != nil {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
@@ -321,7 +322,7 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view container.View, confi
 	if psFilters.Contains("ancestor") {
 		ancestorFilter = true
 		psFilters.WalkValues("ancestor", func(ancestor string) error {
-			img, err := daemon.imageService.GetImage(ctx, ancestor, nil)
+			img, err := daemon.imageService.GetImage(ctx, ancestor, imagetypes.GetImageOpts{})
 			if err != nil {
 				logrus.Warnf("Error while looking up for image %v", ancestor)
 				return nil
@@ -585,7 +586,7 @@ func (daemon *Daemon) refreshImage(ctx context.Context, s *container.Snapshot, f
 	c := s.Container
 	image := s.Image // keep the original ref if still valid (hasn't changed)
 	if image != s.ImageID {
-		img, err := daemon.imageService.GetImage(ctx, image, nil)
+		img, err := daemon.imageService.GetImage(ctx, image, imagetypes.GetImageOpts{})
 		if _, isDNE := err.(images.ErrImageDoesNotExist); err != nil && !isDNE {
 			return nil, err
 		}

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/oci"
@@ -27,7 +28,7 @@ const (
 
 func (daemon *Daemon) createSpec(ctx context.Context, c *container.Container) (*specs.Spec, error) {
 
-	img, err := daemon.imageService.GetImage(ctx, string(c.ImageID), nil)
+	img, err := daemon.imageService.GetImage(ctx, string(c.ImageID), imagetypes.GetImageOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/image/image.go
+++ b/image/image.go
@@ -112,6 +112,17 @@ type Image struct {
 	// computedID is the ID computed from the hash of the image config.
 	// Not to be confused with the legacy V1 ID in V1Image.
 	computedID ID
+
+	// Details holds additional details about image
+	Details *Details `json:"-"`
+}
+
+// Details provides additional image data
+type Details struct {
+	Size        int64
+	Metadata    map[string]string
+	Driver      string
+	LastUpdated time.Time
 }
 
 // RawJSON returns the immutable JSON associated with the image.


### PR DESCRIPTION
**- What I did**
Introduce GetImageWithDetails so that "image inspect" logic is not implement by router but backend, and we can re-implement using containerd snapshotter

relates to https://github.com/moby/moby/pull/43680