### PR TITLE
introduce ImageEventLogger to avoid duplicating logic in containerd_store

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -305,14 +305,6 @@ func newResolverFromAuthConfig(authConfig *types.AuthConfig) (remotes.Resolver, 
 	}), tracker
 }
 
-func (cs *containerdStore) LogImageEvent(imageID, refName, action string) {
-	panic("not implemented")
-}
-
-func (cs *containerdStore) LogImageEventWithAttributes(imageID, refName, action string, attributes map[string]string) {
-	panic("not implemented")
-}
-
 func (cs *containerdStore) GetLayerFolders(img *image.Image, rwLayer layer.RWLayer) ([]string, error) {
 	panic("not implemented")
 }

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -32,8 +32,6 @@ type ImageService interface {
 	ExportImage(ctx context.Context, names []string, outStream io.Writer) error
 	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
-	LogImageEvent(imageID, refName, action string)
-	LogImageEventWithAttributes(imageID, refName, action string, attributes map[string]string)
 	CountImages() int
 	ImageDiskUsage(ctx context.Context) ([]*types.ImageSummary, error)
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*types.ImagesPruneReport, error)

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -105,7 +105,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 
 		untaggedRecord := types.ImageDeleteResponseItem{Untagged: reference.FamiliarString(parsedRef)}
 
-		i.LogImageEvent(imgID.String(), imgID.String(), "untag")
+		i.eventsLogger.LogImageEvent(imgID.String(), imgID.String(), "untag")
 		records = append(records, untaggedRecord)
 
 		repoRefs = i.referenceStore.References(imgID.Digest())
@@ -168,7 +168,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 
 				untaggedRecord := types.ImageDeleteResponseItem{Untagged: reference.FamiliarString(parsedRef)}
 
-				i.LogImageEvent(imgID.String(), imgID.String(), "untag")
+				i.eventsLogger.LogImageEvent(imgID.String(), imgID.String(), "untag")
 				records = append(records, untaggedRecord)
 			}
 		}
@@ -254,7 +254,7 @@ func (i *ImageService) removeAllReferencesToImageID(imgID image.ID, records *[]t
 
 		untaggedRecord := types.ImageDeleteResponseItem{Untagged: reference.FamiliarString(parsedRef)}
 
-		i.LogImageEvent(imgID.String(), imgID.String(), "untag")
+		i.eventsLogger.LogImageEvent(imgID.String(), imgID.String(), "untag")
 		*records = append(*records, untaggedRecord)
 	}
 
@@ -329,7 +329,7 @@ func (i *ImageService) imageDeleteHelper(imgID image.ID, records *[]types.ImageD
 		return err
 	}
 
-	i.LogImageEvent(imgID.String(), imgID.String(), "delete")
+	i.eventsLogger.LogImageEvent(imgID.String(), imgID.String(), "delete")
 	*records = append(*records, types.ImageDeleteResponseItem{Deleted: imgID.String()})
 	for _, removedLayer := range removedLayers {
 		*records = append(*records, types.ImageDeleteResponseItem{Deleted: removedLayer.ChainID.String()})

--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -13,7 +13,7 @@ import (
 // the same tag are exported. names is the set of tags to export, and
 // outStream is the writer which the images are written to.
 func (i *ImageService) ExportImage(ctx context.Context, names []string, outStream io.Writer) error {
-	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
+	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i.eventsLogger.LogImageEvent)
 	return imageExporter.Save(names, outStream)
 }
 
@@ -21,6 +21,6 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 // complement of ExportImage.  The input stream is an uncompressed tar
 // ball containing images and metadata.
 func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
-	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i)
+	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i.eventsLogger.LogImageEvent)
 	return imageExporter.Load(inTar, outStream, quiet)
 }

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -139,7 +139,7 @@ func (i *ImageService) ImportImage(ctx context.Context, src string, repository s
 		}
 	}
 
-	i.LogImageEvent(id.String(), id.String(), "import")
+	i.eventsLogger.LogImageEvent(id.String(), id.String(), "import")
 	outStream.Write(streamformatter.FormatStatus("", id.String()))
 	return nil
 }

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -117,7 +117,7 @@ func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference
 			AuthConfig:       authConfig,
 			ProgressOutput:   progress.ChanOutput(progressChan),
 			RegistryService:  i.registryService,
-			ImageEventLogger: i.LogImageEvent,
+			ImageEventLogger: i.eventsLogger.LogImageEvent,
 			MetadataStore:    i.distributionMetadataStore,
 			ImageStore:       imageStore,
 			ReferenceStore:   i.referenceStore,

--- a/daemon/images/image_push.go
+++ b/daemon/images/image_push.go
@@ -47,7 +47,7 @@ func (i *ImageService) PushImage(ctx context.Context, image, tag string, metaHea
 			AuthConfig:       authConfig,
 			ProgressOutput:   progress.ChanOutput(progressChan),
 			RegistryService:  i.registryService,
-			ImageEventLogger: i.LogImageEvent,
+			ImageEventLogger: i.eventsLogger.LogImageEvent,
 			MetadataStore:    i.distributionMetadataStore,
 			ImageStore:       distribution.NewImageConfigStoreFromStore(i.imageStore),
 			ReferenceStore:   i.referenceStore,

--- a/daemon/images/image_tag.go
+++ b/daemon/images/image_tag.go
@@ -39,6 +39,6 @@ func (i *ImageService) TagImageWithReference(ctx context.Context, imageID image.
 	if err := i.imageStore.SetLastUpdated(imageID); err != nil {
 		return err
 	}
-	i.LogImageEvent(imageID.String(), reference.FamiliarString(newTag), "tag")
+	i.eventsLogger.LogImageEvent(imageID.String(), reference.FamiliarString(newTag), "tag")
 	return nil
 }

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -52,7 +52,7 @@ type ImageServiceConfig struct {
 
 // NewImageService returns a new ImageService from a configuration
 func NewImageService(config ImageServiceConfig) *ImageService {
-	return &ImageService{
+	i := &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,
 		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStore, config.MaxConcurrentDownloads, xfer.WithMaxDownloadAttempts(config.MaxDownloadAttempts)),
@@ -67,6 +67,11 @@ func NewImageService(config ImageServiceConfig) *ImageService {
 		content:                   config.ContentStore,
 		contentNamespace:          config.ContentNamespace,
 	}
+	i.eventsLogger = image.EventLogger{
+		Events:   i.eventsService,
+		GetImage: i.GetImage,
+	}
+	return i
 }
 
 // ImageService provides a backend for image management
@@ -86,6 +91,7 @@ type ImageService struct {
 	content                   content.Store
 	contentNamespace          string
 	usage                     singleflight.Group
+	eventsLogger              image.EventLogger
 }
 
 // DistributionServices provides daemon image storage services

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -134,7 +134,7 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 		}
 
 		parentLinks = append(parentLinks, parentLink{imgID, m.Parent})
-		l.loggerImgEvent.LogImageEvent(imgID.String(), imgID.String(), "load")
+		l.loggerImgEvent(imgID.String(), imgID.String(), "load")
 	}
 
 	for _, p := range validatedParentLinks(parentLinks) {

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -224,7 +224,7 @@ func (s *saveSession) save(outStream io.Writer) error {
 
 		parentID, _ := s.is.GetParent(id)
 		parentLinks = append(parentLinks, parentLink{id, parentID})
-		s.tarexporter.loggerImgEvent.LogImageEvent(id.String(), id.String(), "save")
+		s.tarexporter.loggerImgEvent(id.String(), id.String(), "save")
 	}
 
 	for i, p := range validatedParentLinks(parentLinks) {

--- a/image/tarexport/tarexport.go
+++ b/image/tarexport/tarexport.go
@@ -30,11 +30,8 @@ type tarexporter struct {
 	loggerImgEvent LogImageEvent
 }
 
-// LogImageEvent defines interface for event generation related to image tar(load and save) operations
-type LogImageEvent interface {
-	// LogImageEvent generates an event related to an image operation
-	LogImageEvent(imageID, refName, action string)
-}
+// LogImageEvent defines function to generate events related to image tar(load and save) operations
+type LogImageEvent func(imageID, refName, action string)
 
 // NewTarExporter returns new Exporter for tar packages
 func NewTarExporter(is image.Store, lss layer.Store, rs refstore.Store, loggerImgEvent LogImageEvent) image.Exporter {


### PR DESCRIPTION
**- What I did**
Introduced ImageEventLogger with minimal dependencies to produce daemon events from a single place, and not have to include `LogImageEvent` in the image service interface