### PR TITLE
remove GetLayerByID from ImageService interface

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -25,7 +25,7 @@ type execBackend interface {
 type copyBackend interface {
 	ContainerArchivePath(name string, path string) (content io.ReadCloser, stat *types.ContainerPathStat, err error)
 	ContainerCopy(name string, res string) (io.ReadCloser, error)
-	ContainerExport(name string, out io.Writer) error
+	ContainerExport(ctx context.Context, name string, out io.Writer) error
 	ContainerExtractToDir(name, path string, copyUIDGID, noOverwriteDirNonDir bool, content io.Reader) error
 	ContainerStatPath(name string, path string) (stat *types.ContainerPathStat, err error)
 }

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -170,7 +170,7 @@ func (s *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 }
 
 func (s *containerRouter) getContainersExport(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	return s.backend.ContainerExport(vars["name"], w)
+	return s.backend.ContainerExport(ctx, vars["name"], w)
 }
 
 type bodyOnStartError struct{}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -66,12 +66,6 @@ func (i *ImageService) CreateLayer(container *container.Container, initFunc laye
 	return nil, errors.New("not implemented")
 }
 
-// GetLayerByID returns a layer by ID
-// called from daemon.go Daemon.restore(), and Daemon.containerExport().
-func (i *ImageService) GetLayerByID(cid string) (layer.RWLayer, error) {
-	return nil, errors.New("not implemented")
-}
-
 // LayerStoreStatus returns the status for each layer store
 // called from info.go
 func (i *ImageService) LayerStoreStatus() [][2]string {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -204,6 +204,11 @@ func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 	return resolver.NewRegistryConfig(m)
 }
 
+// layerAccessor may be implemented by ImageService
+type layerAccessor interface {
+	GetLayerByID(cid string) (layer.RWLayer, error)
+}
+
 func (daemon *Daemon) restore(ctx context.Context) error {
 	var mapLock sync.Mutex
 	containers := make(map[string]*container.Container)
@@ -252,12 +257,14 @@ func (daemon *Daemon) restore(ctx context.Context) error {
 			}
 			// Ignore the container if it does not support the current driver being used by the graph
 			if (c.Driver == "" && daemon.graphDriver == "aufs") || c.Driver == daemon.graphDriver {
-				rwlayer, err := daemon.imageService.GetLayerByID(c.ID)
-				if err != nil {
-					log.WithError(err).Error("failed to load container mount")
-					return
+				if accessor, ok := daemon.imageService.(layerAccessor); ok {
+					rwlayer, err := accessor.GetLayerByID(c.ID)
+					if err != nil {
+						log.WithError(err).Error("failed to load container mount")
+						return
+					}
+					c.RWLayer = rwlayer
 				}
-				c.RWLayer = rwlayer
 				log.WithFields(logrus.Fields{
 					"running": c.IsRunning(),
 					"paused":  c.IsPaused(),

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -1,18 +1,19 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"fmt"
 	"io"
 
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/containerfs"
 )
 
 // ContainerExport writes the contents of the container to the given
 // writer. An error is returned if the container cannot be found.
-func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
+func (daemon *Daemon) ContainerExport(ctx context.Context, name string, out io.Writer) error {
 	ctr, err := daemon.GetContainer(name)
 	if err != nil {
 		return err
@@ -32,49 +33,28 @@ func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
 		return errdefs.Conflict(err)
 	}
 
-	data, err := daemon.containerExport(ctr)
+	err = daemon.containerExport(ctx, ctr, out)
 	if err != nil {
 		return fmt.Errorf("Error exporting container %s: %v", name, err)
 	}
-	defer data.Close()
 
-	// Stream the entire contents of the container (basically a volatile snapshot)
-	if _, err := io.Copy(out, data); err != nil {
-		return fmt.Errorf("Error exporting container %s: %v", name, err)
-	}
 	return nil
 }
 
-func (daemon *Daemon) containerExport(container *container.Container) (arch io.ReadCloser, err error) {
-	rwlayer, err := daemon.imageService.GetLayerByID(container.ID)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
+func (daemon *Daemon) containerExport(ctx context.Context, container *container.Container, out io.Writer) error {
+	daemon.imageService.PerformWithBaseFS(ctx, container, func(basefs containerfs.ContainerFS) error {
+		archv, err := archivePath(basefs, basefs.Path(), &archive.TarOptions{
+			Compression: archive.Uncompressed,
+			IDMap:       daemon.idMapping,
+		}, basefs.Path())
 		if err != nil {
-			daemon.imageService.ReleaseLayer(rwlayer)
+			return err
 		}
-	}()
 
-	basefs, err := rwlayer.Mount(container.GetMountLabel())
-	if err != nil {
-		return nil, err
-	}
-
-	archv, err := archivePath(basefs, basefs.Path(), &archive.TarOptions{
-		Compression: archive.Uncompressed,
-		IDMap:       daemon.idMapping,
-	}, basefs.Path())
-	if err != nil {
-		rwlayer.Unmount()
-		return nil, err
-	}
-	arch = ioutils.NewReadCloserWrapper(archv, func() error {
-		err := archv.Close()
-		rwlayer.Unmount()
-		daemon.imageService.ReleaseLayer(rwlayer)
+		// Stream the entire contents of the container (basically a volatile snapshot)
+		_, err = io.Copy(out, archv)
 		return err
 	})
 	daemon.LogContainerEvent(container, "export")
-	return arch, err
+	return nil
 }

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/containerfs"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -30,6 +31,7 @@ type ImageService interface {
 	CreateImage(config []byte, parent string) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
 	ExportImage(ctx context.Context, names []string, outStream io.Writer) error
+	PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(containerfs.ContainerFS) error) error
 	LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error
 	Images(ctx context.Context, opts types.ImageListOptions) ([]*types.ImageSummary, error)
 	CountImages() int
@@ -47,7 +49,6 @@ type ImageService interface {
 
 	GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error)
 	CreateLayer(container *container.Container, initFunc layer.MountInit) (layer.RWLayer, error)
-	GetLayerByID(cid string) (layer.RWLayer, error)
 	LayerStoreStatus() [][2]string
 	GetLayerMountID(cid string) (string, error)
 	ReleaseLayer(rwlayer layer.RWLayer) error

--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"io"
 
+	"github.com/docker/docker/container"
 	"github.com/docker/docker/image/tarexport"
+	"github.com/docker/docker/pkg/containerfs"
 )
 
 // ExportImage exports a list of images to the given output stream. The
@@ -15,6 +17,25 @@ import (
 func (i *ImageService) ExportImage(ctx context.Context, names []string, outStream io.Writer) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i.eventsLogger.LogImageEvent)
 	return imageExporter.Save(names, outStream)
+}
+
+func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(containerfs.ContainerFS) error) error {
+	rwlayer, err := i.GetLayerByID(c.ID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			i.ReleaseLayer(rwlayer)
+		}
+	}()
+
+	basefs, err := rwlayer.Mount(c.GetMountLabel())
+	if err != nil {
+		return err
+	}
+
+	return fn(basefs)
 }
 
 // LoadImage uploads a set of images into the repository. This is the


### PR DESCRIPTION
**- What I did**
removed GetLayerByID from from ImageService interface
replaced by add-hoc cast 

introduce `WithBaseFS` to implement container export