### PR TITLE
Fix `docker system df`

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -183,6 +184,9 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 
 	c, err := i.client.ContainerService().Get(ctx, containerID)
 	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return 0, 0, nil
+		}
 		return 0, 0, err
 	}
 	image, err := i.client.GetImage(ctx, c.Image)

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -14,7 +14,7 @@ import (
 func (daemon *Daemon) ContainerDiskUsage(ctx context.Context) ([]*types.Container, error) {
 	ch := daemon.usage.DoChan("ContainerDiskUsage", func() (interface{}, error) {
 		// Retrieve container list
-		containers, err := daemon.Containers(nil, &types.ContainerListOptions{
+		containers, err := daemon.Containers(ctx, &types.ContainerListOptions{
 			Size: true,
 			All:  true,
 		})

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -10,6 +10,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -181,6 +182,12 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 	if daemon.UsesSnapshotter() {
 		newContainerOpts = append(newContainerOpts, containerd.WithSnapshotter(containerd.DefaultSnapshotter))
 		newContainerOpts = append(newContainerOpts, containerd.WithSnapshot(container.ID))
+		c8dImge, err := daemon.imageService.(containerdImage).GetContainerdImage(ctx, container.Config.Image, &v1.Platform{})
+		if err != nil {
+			return err
+		}
+		ctrdimg := containerd.NewImage(daemon.containerdCli, c8dImge)
+		newContainerOpts = append(newContainerOpts, containerd.WithImage(ctrdimg))
 	}
 
 	err = daemon.containerd.Create(ctx, container.ID, spec, shim, createOptions, newContainerOpts...)


### PR DESCRIPTION
This change fixes multiple things:
* pass ctx instead of nil because we need it while computing the layer
  size
* don't return an error if the container is not found during the layer
  size calculation, if a container is not found it means that it exited
* create the container with the image it was created from, the image is
  used when computing the layer size
