### PR TITLE
Don't remove containerd's container after exit

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -154,6 +154,11 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, config ty
 	for _, name := range linkNames {
 		daemon.releaseName(name)
 	}
+	if daemon.UsesSnapshotter() {
+		if err := daemon.containerd.Delete(context.Background(), container.ID); err != nil {
+			logrus.WithError(err).WithField("container", container.ID).Error("cleanup: failed to delete container from containerd")
+		}
+	}
 	container.SetRemoved()
 	stateCtr.del(container.ID)
 


### PR DESCRIPTION
Keeping the containerd's container around while our container is active makes `docker start` possible.

This is not really ideal, the best way to go about this would be to create the containerd container on create but this would change too much of the logic. Once we switch completely to containerd we can come back to this and change the logic. 


