### PR TITLE
Don't try to restore containers on restart with contaienrd

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -204,6 +204,11 @@ func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 }
 
 func (daemon *Daemon) restore(ctx context.Context) error {
+	// Restoring containers after a restart is not yet supported
+	// when using the containerd content store.
+	if daemon.UsesSnapshotter() {
+		return nil
+	}
 	var mapLock sync.Mutex
 	containers := make(map[string]*container.Container)
 


### PR DESCRIPTION
This needs more work to make containerd the source of truth when it's
used. It's safer for now to not try and restore any containers.

