### PR TITLE
Pass the current snapshotter to the buildkit worker

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -78,6 +78,7 @@ type Opt struct {
 	DNSConfig           config.DNSConfig
 	ApparmorProfile     string
 	UseSnapshotter      bool
+	Snapshotter         string
 	ContainerdAddress   string
 	ContainerdNamespace string
 }

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -75,11 +75,9 @@ func newSnapshotterController(rt http.RoundTripper, opt Opt) (*mobycontrol.Contr
 	}
 	dns := getDNSConfig(opt.DNSConfig)
 
-	snapshotter := ctd.DefaultSnapshotter
-
-	wo, err := containerd.NewWorkerOpt(opt.Root, opt.ContainerdAddress, snapshotter, opt.ContainerdNamespace,
+	wo, err := containerd.NewWorkerOpt(opt.Root, opt.ContainerdAddress, opt.Snapshotter, opt.ContainerdNamespace,
 		opt.Rootless, map[string]string{
-			worker.LabelSnapshotter: snapshotter,
+			worker.LabelSnapshotter: opt.Snapshotter,
 		}, dns, nc, opt.ApparmorProfile, nil, "", ctd.WithTimeout(60*time.Second))
 	if err != nil {
 		return nil, err

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -307,6 +307,7 @@ func newRouterOptions(config *config.Config, d *daemon.Daemon) (routerOptions, e
 		DNSConfig:           config.DNSConfig,
 		ApparmorProfile:     daemon.DefaultApparmorProfile(),
 		UseSnapshotter:      d.UsesSnapshotter(),
+		Snapshotter:         d.ImageService().GraphDriverName(),
 		ContainerdAddress:   config.ContainerdAddr,
 		ContainerdNamespace: config.ContainerdNamespace,
 	})


### PR DESCRIPTION
If buildkit uses a different snapshotter we can't list the images any
more because we can't find the snapshot.

