### PR TITLE
builder-next: reenable runc executor

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -91,6 +91,12 @@ func newSnapshotterController(rt http.RoundTripper, opt Opt) (*mobycontrol.Contr
 	wo.GCPolicy = policy
 	wo.RegistryHosts = opt.RegistryHosts
 
+	exec, err := newExecutor(opt.Root, opt.DefaultCgroupParent, opt.NetworkController, dns, opt.Rootless, opt.IdentityMapping, opt.ApparmorProfile)
+	if err != nil {
+		return nil, err
+	}
+	wo.Executor = exec
+
 	w, err := mobyworker.NewContainerdWorker(context.TODO(), wo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently, without special CNI config the builder would
only create host network containers that is a security issue.

Using runc directly instead of shim is faster as well
as builder doesn’t need anything from shim. The overhead
of setting up network sandbox is much slower of course.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>