### PR TITLE
c8d/prune: Handle filters, don't delete used images

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -270,3 +270,20 @@ func (i *ImageService) resolveImageName(ctx context.Context, refOrID string) (oc
 
 	return img.Target, namedRef, nil
 }
+
+// PresentChildrenHandler traverses recursively all children descriptors that are present in the store.
+func (i *ImageService) presentChildrenHandler() containerdimages.HandlerFunc {
+	store := i.client.ContentStore()
+
+	return func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
+		_, err = store.ReaderAt(ctx, desc)
+		if err != nil {
+			if cerrdefs.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		return containerdimages.Children(ctx, store, desc)
+	}
+}

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -2,11 +2,13 @@ package containerd
 
 import (
 	"context"
+	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	timetypes "github.com/docker/docker/api/types/time"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 )
@@ -159,11 +161,38 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 		return nil, err
 	}
 
+	err = imageFilters.WalkValues("until", func(value string) error {
+		ts, err := timetypes.GetTimestamp(value, time.Now())
+		if err != nil {
+			return err
+		}
+		seconds, nanoseconds, err := timetypes.ParseTimestamps(ts, 0)
+		if err != nil {
+			return err
+		}
+		until := time.Unix(seconds, nanoseconds)
+
+		fltrs = append(fltrs, func(image containerd.Image) bool {
+			created := image.Metadata().CreatedAt
+			return created.Before(until)
+		})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	if imageFilters.Contains("label") {
 		fltrs = append(fltrs, func(image containerd.Image) bool {
 			return imageFilters.MatchKVList("label", image.Labels())
 		})
 	}
+	if imageFilters.Contains("label!") {
+		fltrs = append(fltrs, func(image containerd.Image) bool {
+			return !imageFilters.MatchKVList("label!", image.Labels())
+		})
+	}
+
 	return func(image containerd.Image) bool {
 		for _, filter := range fltrs {
 			if !filter(image) {

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -21,10 +21,11 @@ import (
 
 // ImageService implements daemon.ImageService
 type ImageService struct {
-	client      *containerd.Client
-	usage       singleflight.Group
-	containers  container.Store
-	snapshotter string
+	client       *containerd.Client
+	usage        singleflight.Group
+	containers   container.Store
+	snapshotter  string
+	pruneRunning int32
 }
 
 // NewService creates a new ImageService.


### PR DESCRIPTION
Support the same filters as the non-c8d docker for `image prune -a`.
Also no longer remove the content from ContentStore ourselves - let c8d do that when deleting Image with SynchronousDelete (triggers GC immediately), and check afterwards which blobs are no longer in the store.

Not sure if there's anything meaningful from our side to do in `docker image prune`, as there is no dangling images in c8d due to GC. So currently the only sensible thing is to just trigger the GC, in case there were performed some actions without `SynchronousDelete` option.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

