### PR TITLE
daemon/config: remove unused DefaultContainerdSnapshotter

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/registry"
@@ -51,9 +50,6 @@ const (
 	DefaultContainersNamespace = "moby"
 	// DefaultPluginNamespace is the name of the default containerd namespace used for plugins.
 	DefaultPluginNamespace = "plugins.moby"
-
-	// DefaultContainerdSnapshotter is the name of the default containerd snapshotter used for creating container root fs
-	DefaultContainerdSnapshotter = containerd.DefaultSnapshotter
 
 	// LinuxV2RuntimeName is the runtime used to specify the containerd v2 runc shim
 	LinuxV2RuntimeName = "io.containerd.runc.v2"


### PR DESCRIPTION
This was added as part of rumpl/moby#40, but wasn't used.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

