### PR TITLE
ImageService: rename GraphDriverName to StorageDriver, remove daemon.graphdriver

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -307,7 +307,7 @@ func newRouterOptions(config *config.Config, d *daemon.Daemon) (routerOptions, e
 		DNSConfig:           config.DNSConfig,
 		ApparmorProfile:     daemon.DefaultApparmorProfile(),
 		UseSnapshotter:      d.UsesSnapshotter(),
-		Snapshotter:         d.ImageService().GraphDriverName(),
+		Snapshotter:         d.ImageService().StorageDriver(),
 		ContainerdAddress:   config.ContainerdAddr,
 		ContainerdNamespace: config.ContainerdNamespace,
 	})

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -154,7 +154,7 @@ func (daemon *Daemon) newContainer(name string, operatingSystem string, config *
 	base.ImageID = imgID
 	base.NetworkSettings = &network.Settings{IsAnonymousEndpoint: noExplicitName}
 	base.Name = name
-	base.Driver = daemon.imageService.GraphDriverName()
+	base.Driver = daemon.imageService.StorageDriver()
 	base.OS = operatingSystem
 	return base, err
 }

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -60,7 +60,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 			References:  tags,
 			Size:        size,
 			Metadata:    nil,
-			Driver:      i.GraphDriverName(),
+			Driver:      i.StorageDriver(),
 			LastUpdated: ii.Metadata().UpdatedAt,
 		}
 	}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -86,11 +86,9 @@ func (i *ImageService) Cleanup() error {
 	return nil
 }
 
-// GraphDriverName returns the name of the graph drvier
-// moved from Daemon.GraphDriverName, used by:
-// - newContainer
-// - to report an error in Daemon.Mount(container)
-func (i *ImageService) GraphDriverName() string {
+// StorageDriver returns the name of the default storage-driver (snapshotter)
+// used by the ImageService.
+func (i *ImageService) StorageDriver() string {
 	return i.snapshotter
 }
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -190,7 +190,7 @@ func (daemon *Daemon) create(ctx context.Context, opts createOpts) (retC *contai
 			return nil, err
 		}
 		parent := identity.ChainID(diffIDs).String()
-		s := daemon.containerdCli.SnapshotService(daemon.graphDriver)
+		s := daemon.containerdCli.SnapshotService(daemon.ImageService().StorageDriver())
 		if _, err := s.Prepare(ctx, ctr.ID, parent); err != nil {
 			return nil, err
 		}
@@ -202,7 +202,7 @@ func (daemon *Daemon) create(ctx context.Context, opts createOpts) (retC *contai
 		}
 		ls.AddResource(ctx, lease, leases.Resource{
 			ID:   ctr.ID,
-			Type: "snapshots/" + daemon.graphDriver,
+			Type: "snapshots/" + daemon.imageService.StorageDriver(),
 		})
 	} else {
 		// Set RWLayer for container after mount labels have been set

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -73,6 +73,6 @@ type ImageService interface {
 	DistributionServices() images.DistributionServices
 	Children(id image.ID) []image.ID
 	Cleanup() error
-	GraphDriverName() string
+	StorageDriver() string
 	UpdateConfig(maxDownloads, maxUploads int)
 }

--- a/daemon/images/mount.go
+++ b/daemon/images/mount.go
@@ -29,7 +29,7 @@ func (i *ImageService) Mount(ctx context.Context, container *container.Container
 		if runtime.GOOS != "windows" {
 			i.Unmount(ctx, container)
 			return fmt.Errorf("Error: driver %s is returning inconsistent paths for container %s ('%s' then '%s')",
-				i.GraphDriverName(), container.ID, container.BaseFS, dir)
+				i.StorageDriver(), container.ID, container.BaseFS, dir)
 		}
 	}
 	container.BaseFS = dir // TODO: combine these fields

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -178,11 +178,8 @@ func (i *ImageService) Cleanup() error {
 	return nil
 }
 
-// GraphDriverName returns the name of the graph drvier
-// moved from Daemon.GraphDriverName, used by:
-// - newContainer
-// - to report an error in Daemon.Mount(container)
-func (i *ImageService) GraphDriverName() string {
+// StorageDriver returns the name of the storage driver used by the ImageService.
+func (i *ImageService) StorageDriver() string {
 	return i.layerStore.DriverName()
 }
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -120,17 +120,17 @@ func (daemon *Daemon) SystemVersion() types.Version {
 }
 
 func (daemon *Daemon) fillDriverInfo(v *types.Info) {
+	v.Driver = daemon.imageService.StorageDriver()
+	v.DriverStatus = daemon.imageService.LayerStoreStatus()
+
 	const warnMsg = `
 WARNING: The %s storage-driver is deprecated, and will be removed in a future release.
          Refer to the documentation for more information: https://docs.docker.com/go/storage-driver/`
 
-	switch daemon.graphDriver {
+	switch v.Driver {
 	case "aufs", "devicemapper", "overlay":
-		v.Warnings = append(v.Warnings, fmt.Sprintf(warnMsg, daemon.graphDriver))
+		v.Warnings = append(v.Warnings, fmt.Sprintf(warnMsg, v.Driver))
 	}
-
-	v.Driver = daemon.graphDriver
-	v.DriverStatus = daemon.imageService.LayerStoreStatus()
 
 	fillDriverWarnings(v)
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -1064,9 +1064,8 @@ func (daemon *Daemon) createSpec(ctx context.Context, c *container.Container) (r
 	snapshotter := ""
 	snapshotKey := ""
 	if daemon.UsesSnapshotter() {
-		snapshotter = daemon.graphDriver
+		snapshotter = daemon.ImageService().StorageDriver()
 		snapshotKey = c.ID
-
 	}
 
 	return &s, coci.ApplyOpts(context.Background(), daemon.containerdCli, &containers.Container{

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -180,7 +180,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 
 	newContainerOpts := []containerd.NewContainerOpts{}
 	if daemon.UsesSnapshotter() {
-		newContainerOpts = append(newContainerOpts, containerd.WithSnapshotter(daemon.graphDriver))
+		newContainerOpts = append(newContainerOpts, containerd.WithSnapshotter(daemon.ImageService().StorageDriver()))
 		newContainerOpts = append(newContainerOpts, containerd.WithSnapshot(container.ID))
 		c8dImge, err := daemon.imageService.(containerdImage).GetContainerdImage(ctx, container.Config.Image, &v1.Platform{})
 		if err != nil {


### PR DESCRIPTION
- same as https://github.com/moby/moby/pull/43982

### ImageService: rename GraphDriverName to StorageDriver

Make the function name more generic, as it's no longer used only for graphdrivers but also for snapshotters.

### daemon: info: fillDriverInfo() get driver-name from ImageService

Make the ImageService the source of truth for the storage-driver that's used.

### daemon: remove daemon.graphdriver

It was only used as an intermediate variable to store what's returned
by layerstore.DriverName() / ImageService.StorageDriver()


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


