### PR TITLE
c8d/progress: Fix progress not ending

### DIFF
--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -29,7 +29,6 @@ func showProgress(ctx context.Context, ongoing *jobs, w io.Writer, updateFunc up
 		out    = streamformatter.NewJSONProgressOutput(w, false)
 		ticker = time.NewTicker(100 * time.Millisecond)
 		start  = time.Now()
-		done   bool
 	)
 
 	for _, j := range ongoing.Jobs() {
@@ -54,12 +53,9 @@ func showProgress(ctx context.Context, ongoing *jobs, w io.Writer, updateFunc up
 					logrus.WithError(err).Error("Updating progress failed")
 					return
 				}
-
-				if done {
-					return
-				}
 			case <-ctx.Done():
-				done = true
+				updateFunc(ctx, ongoing, out, start)
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
Fix a bug which makes the progress handler never end if an error
happens before any ongoing is added.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

