### PR TITLE
info: add driver-type, and add utility to check if snapshotters are enabled 

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/containerd"
 	cerrdefs "github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -70,7 +71,10 @@ func (i *ImageService) CreateLayer(container *container.Container, initFunc laye
 // LayerStoreStatus returns the status for each layer store
 // called from info.go
 func (i *ImageService) LayerStoreStatus() [][2]string {
-	return [][2]string{}
+	// TODO(thaJeztah) do we want to add more details about the driver here?
+	return [][2]string{
+		{"driver-type", string(plugin.SnapshotPlugin)},
+	}
 }
 
 // GetLayerMountID returns the mount ID for a layer

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -42,8 +42,7 @@ func (s *DockerCLIInspectSuite) TestInspectImage(c *testing.T) {
 	// fails, fix the difference in the image serialization instead of
 	// updating this hash.
 	imageTestID := "sha256:11f64303f0f7ffdc71f001788132bca5346831939a956e3e975c93267d89a16d"
-	usesContainerdSnapshotter := false // TODO(vvoland): Check for feature flag
-	if usesContainerdSnapshotter {
+	if containerdSnapshotterEnabled() {
 		// Under containerd ID of the image is the digest of the manifest list.
 		imageTestID = "sha256:e43ca824363c5c56016f6ede3a9035afe0e9bd43333215e0b0bde6193969725d"
 	}

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/plugin"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
@@ -97,6 +98,17 @@ func Apparmor() bool {
 
 func Devicemapper() bool {
 	return strings.HasPrefix(testEnv.DaemonInfo.Driver, "devicemapper")
+}
+
+// containerdSnapshotterEnabled checks if the daemon in the test-environment is
+// configured with containerd-snapshotters enabled.
+func containerdSnapshotterEnabled() bool {
+	for _, v := range testEnv.DaemonInfo.DriverStatus {
+		if v[0] == "driver-type" {
+			return v[1] == string(plugin.SnapshotPlugin)
+		}
+	}
+	return false
 }
 
 func IPv6() bool {


### PR DESCRIPTION
forward ports upstream changes from:

- second commit from https://github.com/moby/moby/pull/43983
- https://github.com/moby/moby/pull/44011
- relates to https://github.com/rumpl/moby/pull/31#discussion_r932522838