### PR TITLE
image commit: use configured snapshotter instead of default

### DIFF
--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -74,7 +74,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 
 	var (
 		differ = i.client.DiffService()
-		sn     = i.client.SnapshotService(containerd.DefaultSnapshotter)
+		sn     = i.client.SnapshotService(i.snapshotter)
 	)
 
 	// Don't gc me and clean the dirty data after 1 hour!
@@ -100,7 +100,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 	}
 
 	layers := append(ocimanifest.Layers, diffLayerDesc)
-	commitManifestDesc, configDigest, err := writeContentsForImage(ctx, containerd.DefaultSnapshotter, baseImg, imageConfig, layers)
+	commitManifestDesc, configDigest, err := writeContentsForImage(ctx, i.snapshotter, baseImg, imageConfig, layers)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- relates to https://github.com/rumpl/moby/pull/40
- relates to https://github.com/rumpl/moby/pull/37


**- A picture of a cute animal (not mandatory but encouraged)**

