### PR TITLE
daemon: set containerd default snapshotter if none is configured

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1004,6 +1004,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 
 	if d.UsesSnapshotter() {
+		// FIXME(thaJeztah): implement snapshotter-selection similar to automatic graph-driver selection
+		if driverName == "" || driverName == "overlay2" || driverName == "overlay" {
+			driverName = containerd.DefaultSnapshotter
+		}
+
 		// Configure and validate the kernels security support. Note this is a Linux/FreeBSD
 		// operation only, so it is safe to pass *just* the runtime OS graphdriver.
 		if err := configureKernelSecuritySupport(config, driverName); err != nil {


### PR DESCRIPTION
- relates to https://github.com/rumpl/moby/pull/77


see https://github.com/rumpl/moby/pull/77#issuecomment-1226092727

This is a temporary workaround for the daemon not yet having automatic
selection of snapshotters.


**- A picture of a cute animal (not mandatory but encouraged)**

