### PR TITLE
c8d/resolver: Use hosts from daemon configuration

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -45,7 +45,7 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 		}
 	}
 
-	resolver, _ := newResolverFromAuthConfig(authConfig)
+	resolver, _ := i.newResolverFromAuthConfig(authConfig)
 	opts = append(opts, containerd.WithResolver(resolver))
 
 	jobs := newJobs()

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -85,7 +85,7 @@ func (i *ImageService) PushImage(ctx context.Context, image, tag string, metaHea
 	})
 	imageHandler = remotes.SkipNonDistributableBlobs(imageHandler)
 
-	resolver, tracker := newResolverFromAuthConfig(authConfig)
+	resolver, tracker := i.newResolverFromAuthConfig(authConfig)
 
 	finishProgress := showProgress(ctx, jobs, outStream, pushProgress(tracker))
 	defer finishProgress()

--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -8,32 +8,52 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func newResolverFromAuthConfig(authConfig *registrytypes.AuthConfig) (remotes.Resolver, docker.StatusTracker) {
-	opts := []docker.RegistryOpt{}
-
-	if authConfig != nil {
-		cfgHost := registry.ConvertToHostname(authConfig.ServerAddress)
-		if cfgHost == registry.IndexHostname {
-			cfgHost = registry.DefaultRegistryHost
-		}
-		authorizer := docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {
-			if cfgHost != host {
-				logrus.WithField("host", host).WithField("cfgHost", cfgHost).Warn("Host doesn't match")
-				return "", "", nil
-			}
-			if authConfig.IdentityToken != "" {
-				return "", authConfig.IdentityToken, nil
-			}
-			return authConfig.Username, authConfig.Password, nil
-		}))
-
-		opts = append(opts, docker.WithAuthorizer(authorizer))
-	}
+func (i *ImageService) newResolverFromAuthConfig(authConfig *registrytypes.AuthConfig) (remotes.Resolver, docker.StatusTracker) {
+	hostsFn := i.registryHosts.RegistryHosts()
+	hosts := hostsAuthorizerWrapper(hostsFn, authConfig)
 
 	tracker := docker.NewInMemoryTracker()
 
 	return docker.NewResolver(docker.ResolverOptions{
-		Hosts:   docker.ConfigureDefaultRegistries(opts...),
+		Hosts:   hosts,
 		Tracker: tracker,
 	}), tracker
+}
+
+func hostsAuthorizerWrapper(hostsFn docker.RegistryHosts, authConfig *registrytypes.AuthConfig) docker.RegistryHosts {
+	return docker.RegistryHosts(func(n string) ([]docker.RegistryHost, error) {
+		hosts, err := hostsFn(n)
+		if err == nil {
+			for idx, host := range hosts {
+				if host.Authorizer == nil {
+					var opts []docker.AuthorizerOpt
+					if authConfig != nil {
+						opts = append(opts, authorizationCredsFromAuthConfig(*authConfig))
+					}
+					host.Authorizer = docker.NewDockerAuthorizer(opts...)
+					hosts[idx] = host
+				}
+			}
+		}
+
+		return hosts, err
+	})
+}
+
+func authorizationCredsFromAuthConfig(authConfig registrytypes.AuthConfig) docker.AuthorizerOpt {
+	cfgHost := registry.ConvertToHostname(authConfig.ServerAddress)
+	if cfgHost == registry.IndexHostname {
+		cfgHost = registry.DefaultRegistryHost
+	}
+
+	return docker.WithAuthCreds(func(host string) (string, string, error) {
+		if cfgHost != host {
+			logrus.WithField("host", host).WithField("cfgHost", cfgHost).Warn("Host doesn't match")
+			return "", "", nil
+		}
+		if authConfig.IdentityToken != "" {
+			return "", authConfig.IdentityToken, nil
+		}
+		return authConfig.Username, authConfig.Password, nil
+	})
 }

--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -1,6 +1,9 @@
 package containerd
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -9,10 +12,10 @@ import (
 )
 
 func (i *ImageService) newResolverFromAuthConfig(authConfig *registrytypes.AuthConfig) (remotes.Resolver, docker.StatusTracker) {
-	hostsFn := i.registryHosts.RegistryHosts()
-	hosts := hostsAuthorizerWrapper(hostsFn, authConfig)
-
 	tracker := docker.NewInMemoryTracker()
+	hostsFn := i.registryHosts.RegistryHosts()
+
+	hosts := hostsWrapper(hostsFn, authConfig, i.registryService)
 
 	return docker.NewResolver(docker.ResolverOptions{
 		Hosts:   hosts,
@@ -20,9 +23,10 @@ func (i *ImageService) newResolverFromAuthConfig(authConfig *registrytypes.AuthC
 	}), tracker
 }
 
-func hostsAuthorizerWrapper(hostsFn docker.RegistryHosts, authConfig *registrytypes.AuthConfig) docker.RegistryHosts {
+func hostsWrapper(hostsFn docker.RegistryHosts, authConfig *registrytypes.AuthConfig, regService *registry.Service) docker.RegistryHosts {
 	return docker.RegistryHosts(func(n string) ([]docker.RegistryHost, error) {
 		hosts, err := hostsFn(n)
+
 		if err == nil {
 			for idx, host := range hosts {
 				if host.Authorizer == nil {
@@ -31,6 +35,11 @@ func hostsAuthorizerWrapper(hostsFn docker.RegistryHosts, authConfig *registryty
 						opts = append(opts, authorizationCredsFromAuthConfig(*authConfig))
 					}
 					host.Authorizer = docker.NewDockerAuthorizer(opts...)
+
+					isInsecure := regService.IsInsecureRegistry(host.Host)
+					if host.Client.Transport != nil && isInsecure {
+						host.Client.Transport = httpFallback{super: host.Client.Transport}
+					}
 					hosts[idx] = host
 				}
 			}
@@ -56,4 +65,25 @@ func authorizationCredsFromAuthConfig(authConfig registrytypes.AuthConfig) docke
 		}
 		return authConfig.Username, authConfig.Password, nil
 	})
+}
+
+type httpFallback struct {
+	super http.RoundTripper
+}
+
+func (f httpFallback) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := f.super.RoundTrip(r)
+	if err != nil {
+		if strings.Contains(err.Error(), "http: server gave HTTP response to HTTPS client") {
+			plainHttpUrl := *r.URL
+			plainHttpUrl.Scheme = "http"
+
+			plainHttpRequest := *r
+			plainHttpRequest.URL = &plainHttpUrl
+
+			return http.DefaultTransport.RoundTrip(&plainHttpRequest)
+		}
+	}
+
+	return resp, err
 }

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd"
 	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/plugin"
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -22,19 +23,25 @@ import (
 
 // ImageService implements daemon.ImageService
 type ImageService struct {
-	client       *containerd.Client
-	usage        singleflight.Group
-	containers   container.Store
-	snapshotter  string
-	pruneRunning int32
+	client        *containerd.Client
+	usage         singleflight.Group
+	containers    container.Store
+	snapshotter   string
+	pruneRunning  int32
+	registryHosts RegistryHostsProvider
+}
+
+type RegistryHostsProvider interface {
+	RegistryHosts() docker.RegistryHosts
 }
 
 // NewService creates a new ImageService.
-func NewService(c *containerd.Client, containers container.Store, snapshotter string) *ImageService {
+func NewService(c *containerd.Client, containers container.Store, snapshotter string, hostsProvider RegistryHostsProvider) *ImageService {
 	return &ImageService{
-		client:      c,
-		containers:  containers,
-		snapshotter: snapshotter,
+		client:        c,
+		containers:    containers,
+		snapshotter:   snapshotter,
+		registryHosts: hostsProvider,
 	}
 }
 

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
+	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	"golang.org/x/sync/singleflight"
@@ -23,12 +24,13 @@ import (
 
 // ImageService implements daemon.ImageService
 type ImageService struct {
-	client        *containerd.Client
-	usage         singleflight.Group
-	containers    container.Store
-	snapshotter   string
-	pruneRunning  int32
-	registryHosts RegistryHostsProvider
+	client          *containerd.Client
+	usage           singleflight.Group
+	containers      container.Store
+	snapshotter     string
+	pruneRunning    int32
+	registryHosts   RegistryHostsProvider
+	registryService *registry.Service
 }
 
 type RegistryHostsProvider interface {
@@ -36,12 +38,13 @@ type RegistryHostsProvider interface {
 }
 
 // NewService creates a new ImageService.
-func NewService(c *containerd.Client, containers container.Store, snapshotter string, hostsProvider RegistryHostsProvider) *ImageService {
+func NewService(c *containerd.Client, containers container.Store, snapshotter string, hostsProvider RegistryHostsProvider, registry *registry.Service) *ImageService {
 	return &ImageService{
-		client:        c,
-		containers:    containers,
-		snapshotter:   snapshotter,
-		registryHosts: hostsProvider,
+		client:          c,
+		containers:      containers,
+		snapshotter:     snapshotter,
+		registryHosts:   hostsProvider,
+		registryService: registry,
 	}
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -173,6 +174,13 @@ func (daemon *Daemon) RegistryHosts() docker.RegistryHosts {
 
 	for _, v := range daemon.configStore.InsecureRegistries {
 		u, err := url.Parse(v)
+		if err != nil && !strings.HasPrefix(v, "http://") && !strings.HasPrefix(v, "https://") {
+			originalErr := err
+			u, err = url.Parse("http://" + v)
+			if err != nil {
+				err = originalErr
+			}
+		}
 		c := resolverconfig.RegistryConfig{}
 		if err == nil {
 			v = u.Host
@@ -1014,7 +1022,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		if err := configureKernelSecuritySupport(config, driverName); err != nil {
 			return nil, err
 		}
-		d.imageService = ctrd.NewService(d.containerdCli, d.containers, driverName, d)
+		d.imageService = ctrd.NewService(d.containerdCli, d.containers, driverName, d, d.registryService)
 	} else {
 		layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{
 			Root:                      config.Root,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1014,7 +1014,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		if err := configureKernelSecuritySupport(config, driverName); err != nil {
 			return nil, err
 		}
-		d.imageService = ctrd.NewService(d.containerdCli, d.containers, driverName)
+		d.imageService = ctrd.NewService(d.containerdCli, d.containers, driverName, d)
 	} else {
 		layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{
 			Root:                      config.Root,

--- a/registry/service.go
+++ b/registry/service.go
@@ -146,3 +146,9 @@ func (s *Service) LookupPushEndpoints(hostname string) (endpoints []APIEndpoint,
 	}
 	return endpoints, err
 }
+
+// IsInsecureRegistry returns false if the registry at given host is configured as
+// insecure registry.
+func (s *Service) IsInsecureRegistry(host string) bool {
+	return !s.config.isSecureIndex(host)
+}


### PR DESCRIPTION
This makes the containerd pull/push respect the insecureRegistries configuration.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

