### PR TITLE
c8d/progress: Don't use cancelled context

### DIFF
--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -54,6 +54,9 @@ func showProgress(ctx context.Context, ongoing *jobs, w io.Writer, updateFunc up
 					return
 				}
 			case <-ctx.Done():
+				// Don't use the context that is already done.
+				// Perform the last update with a new context.
+				ctx := context.Background()
 				updateFunc(ctx, ongoing, out, start)
 				return
 			}


### PR DESCRIPTION
Related to:
- https://github.com/rumpl/moby/pull/73

Last progress update is performed with context that is already cancelled/done, so any operation accepting the context wasn't able to finish successfully.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

