### PR TITLE
Set the user on exec

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -256,7 +256,7 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 		p.Cwd = "/"
 	}
 
-	if err := daemon.execSetPlatformOpt(c, ec, p); err != nil {
+	if err := daemon.execSetPlatformOpt(ctx, c, ec, p); err != nil {
 		return err
 	}
 

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -3,6 +3,9 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	coci "github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/apparmor"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/exec"
@@ -10,12 +13,48 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config, p *specs.Process) error {
+// withResetAdditionalGIDs resets additonal GIDs
+// This code is based  nerdctl, under Apache License
+// https://github.com/containerd/nerdctl/blob/2bbd998a1c95e6682120918d9a07a24ccef4f5fb/cmd/nerdctl/run_user.go#L69
+func withResetAdditionalGIDs() oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+		s.Process.User.AdditionalGids = nil
+		return nil
+	}
+}
+
+func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, c *container.Container, ec *exec.Config, p *specs.Process) error {
 	if len(ec.User) > 0 {
-		var err error
-		p.User, err = getUser(c, ec.User)
-		if err != nil {
-			return err
+		if daemon.UsesSnapshotter() {
+			cc, err := daemon.containerdCli.LoadContainer(ctx, c.ID)
+			if err != nil {
+				return err
+			}
+			ci, err := cc.Info(ctx)
+			if err != nil {
+				return err
+			}
+			spec, err := cc.Spec(ctx)
+			if err != nil {
+				return err
+			}
+			opts := []oci.SpecOpts{
+				coci.WithUser(ec.User),
+				withResetAdditionalGIDs(),
+				coci.WithAdditionalGIDs(ec.User),
+			}
+			for _, opt := range opts {
+				if err := opt(ctx, daemon.containerdCli, &ci, spec); err != nil {
+					return err
+				}
+			}
+			p.User = spec.Process.User
+		} else {
+			var err error
+			p.User, err = getUser(c, ec.User)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if ec.Privileged {

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -4,6 +4,7 @@
 package daemon
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containerd/containerd/pkg/apparmor"
@@ -82,7 +83,7 @@ func TestExecSetPlatformOptAppArmor(t *testing.T) {
 				ec := &exec.Config{Privileged: execPrivileged}
 				p := &specs.Process{}
 
-				err := d.execSetPlatformOpt(c, ec, p)
+				err := d.execSetPlatformOpt(context.TODO(), c, ec, p)
 				assert.NilError(t, err)
 				assert.Equal(t, p.ApparmorProfile, tc.expectedProfile)
 			})

--- a/daemon/exec_windows.go
+++ b/daemon/exec_windows.go
@@ -1,12 +1,14 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/exec"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func (daemon *Daemon) execSetPlatformOpt(c *container.Container, ec *exec.Config, p *specs.Process) error {
+func (daemon *Daemon) execSetPlatformOpt(_ context.Context, c *container.Container, ec *exec.Config, p *specs.Process) error {
 	if c.OS == "windows" {
 		p.User.Username = ec.User
 	}


### PR DESCRIPTION
**- What I did**

Fixed exec when specifiying a user:

```
$ docker run -d --rm -it ubuntu /bin/bash 
fb183991d3b1a2fbcea9d97b49a01cfefd7869ca6a4d428cdd0843853468ec25
$ docker exec -u 1000 fb183991d3b1a2fbcea9d97b49a01cfefd7869ca6a4d428cdd0843853468ec25 id
uid=1000 gid=0(root) groups=0(root)
```

**- How I did it**

By getting the container from containerd and asking it to populate the spec with the right user.

