### PR TITLE
detect HTTP response to HTTPS request

### DIFF
--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -1,8 +1,8 @@
 package containerd
 
 import (
+	"crypto/tls"
 	"net/http"
-	"strings"
 
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
@@ -73,16 +73,15 @@ type httpFallback struct {
 
 func (f httpFallback) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, err := f.super.RoundTrip(r)
-	if err != nil {
-		if strings.Contains(err.Error(), "http: server gave HTTP response to HTTPS client") {
-			plainHttpUrl := *r.URL
-			plainHttpUrl.Scheme = "http"
+	if tlsErr, ok := err.(tls.RecordHeaderError); ok && string(tlsErr.RecordHeader[:]) == "HTTP/" {
+		// server gave HTTP response to HTTPS client
+		plainHttpUrl := *r.URL
+		plainHttpUrl.Scheme = "http"
 
-			plainHttpRequest := *r
-			plainHttpRequest.URL = &plainHttpUrl
+		plainHttpRequest := *r
+		plainHttpRequest.URL = &plainHttpUrl
 
-			return http.DefaultTransport.RoundTrip(&plainHttpRequest)
-		}
+		return http.DefaultTransport.RoundTrip(&plainHttpRequest)
 	}
 
 	return resp, err


### PR DESCRIPTION
httpfalback is responsible to retry access to insecure registry with plain HTTP, so it must detect incorrect response ent by registry to HTTPS request. As this takes place inside net/http/client we need to duplicate #send error detection