### PR TITLE
Return the image ID on inspect

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -201,6 +201,13 @@ type ChildConfig struct {
 	Config          *container.Config
 }
 
+// NewImage creates a new image with the given ID
+func NewImage(id ID) *Image {
+	return &Image{
+		computedID: id,
+	}
+}
+
 // NewChildImage creates a new Image as a child of this image.
 func NewChildImage(img *Image, child ChildConfig, os string) *Image {
 	isEmptyLayer := layer.IsEmpty(child.DiffID)


### PR DESCRIPTION
**- What I did**

Created a new function in the `image` package to be able to create an image with a given ID, this is needed because the image id is read-only and created by the image store on image creation. We no longer use the image store with containerd and need a way to return an image with its ID.

With this change k8s on Desktop works

<img width="1359" alt="Screenshot 2022-09-13 at 17 03 18" src="https://user-images.githubusercontent.com/99933/189937195-ccc49999-95ab-4ae3-a8bb-74ec0c2a695c.png">

**- How to verify it**

```
$ docker pull hello-world
$ docker inspect hello-world
```
The inspect JSON should have an ID that is not empty

