### PR TITLE
Make sure the mount is readonly when searching for a user/group

### DIFF
--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -2,85 +2,61 @@ package containerd
 
 import (
 	"context"
-	"strings"
+	"fmt"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/google/uuid"
 	"github.com/opencontainers/image-spec/identity"
 )
 
-func (i *ImageService) Changes(ctx context.Context, container *container.Container) ([]archive.Change, error) {
+func (i *ImageService) Changes(ctx context.Context, container *container.Container) (changes []archive.Change, err error) {
 	snapshotter := i.client.SnapshotService(i.snapshotter)
-	mounts, err := snapshotter.Mounts(ctx, container.ID)
+	mounts, uerr := snapshotter.Mounts(ctx, container.ID)
 	if err != nil {
-		return nil, err
+		return nil, uerr
 	}
 
-	cimg, _, err := i.getImage(ctx, container.Config.Image)
-	if err != nil {
-		return nil, err
+	cimg, _, uerr := i.getImage(ctx, container.Config.Image)
+	if uerr != nil {
+		return nil, uerr
 	}
-	baseImgWithoutPlatform, err := i.client.ImageService().Get(ctx, cimg.Name())
-	if err != nil {
-		return nil, err
+	baseImgWithoutPlatform, uerr := i.client.ImageService().Get(ctx, cimg.Name())
+	if uerr != nil {
+		return nil, uerr
 	}
 	baseImg := containerd.NewImageWithPlatform(i.client, baseImgWithoutPlatform, platforms.DefaultStrict())
-	diffIDs, err := baseImg.RootFS(ctx)
-	rnd, err := uuid.NewRandom()
-	if err != nil {
-		return nil, err
+	diffIDs, uerr := baseImg.RootFS(ctx)
+	if uerr != nil {
+		return nil, uerr
 	}
-	parent, err := snapshotter.View(ctx, rnd.String(), identity.ChainID(diffIDs).String())
-	if err != nil {
-		return nil, err
+	rnd, uerr := uuid.NewRandom()
+	if uerr != nil {
+		return nil, uerr
 	}
-	defer snapshotter.Remove(ctx, rnd.String())
+	parent, uerr := snapshotter.View(ctx, rnd.String(), identity.ChainID(diffIDs).String())
+	if uerr != nil {
+		return nil, uerr
+	}
+	defer func() {
+		uerr = snapshotter.Remove(ctx, rnd.String())
+		if err == nil {
+			err = uerr
+		} else {
+			err = fmt.Errorf("%s: %w", uerr.Error(), err)
+		}
+	}()
 
-	var changes []archive.Change
-	err = mount.WithTempMount(ctx, readOnly(mounts), func(fs string) error {
+	err = mount.WithTempMount(ctx, oci.ReadonlyMounts(mounts), func(fs string) error {
 		return mount.WithTempMount(ctx, parent, func(root string) error {
 			changes, err = archive.ChangesDirs(fs, root)
 			return err
 		})
-		return err
 	})
-	return changes, err
-}
 
-func readOnly(mounts []mount.Mount) []mount.Mount {
-	for i, m := range mounts {
-		if m.Type == "overlay" {
-			opts := make([]string, 0, len(m.Options))
-			upper := ""
-			for _, o := range m.Options {
-				if strings.HasPrefix(o, "upperdir=") {
-					upper = strings.TrimPrefix(o, "upperdir=")
-				} else if !strings.HasPrefix(o, "workdir=") {
-					opts = append(opts, o)
-				}
-			}
-			if upper != "" {
-				for i, o := range opts {
-					if strings.HasPrefix(o, "lowerdir=") {
-						opts[i] = "lowerdir=" + upper + ":" + strings.TrimPrefix(o, "lowerdir=")
-					}
-				}
-			}
-			mounts[i].Options = opts
-			continue
-		}
-		opts := make([]string, 0, len(m.Options))
-		for _, opt := range m.Options {
-			if opt != "rw" {
-				opts = append(opts, opt)
-			}
-		}
-		opts = append(opts, "ro")
-		mounts[i].Options = opts
-	}
-	return mounts
+	return changes, err
 }

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -3,25 +3,14 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 
-	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/oci"
 	coci "github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/apparmor"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/exec"
+	"github.com/docker/docker/oci"
 	"github.com/docker/docker/oci/caps"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
-
-// withResetAdditionalGIDs resets additonal GIDs
-// This code is based  nerdctl, under Apache License
-// https://github.com/containerd/nerdctl/blob/2bbd998a1c95e6682120918d9a07a24ccef4f5fb/cmd/nerdctl/run_user.go#L69
-func withResetAdditionalGIDs() oci.SpecOpts {
-	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-		s.Process.User.AdditionalGids = nil
-		return nil
-	}
-}
 
 func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, c *container.Container, ec *exec.Config, p *specs.Process) error {
 	if len(ec.User) > 0 {
@@ -30,18 +19,18 @@ func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, c *container.Conta
 			if err != nil {
 				return err
 			}
-			ci, err := cc.Info(ctx)
-			if err != nil {
-				return err
-			}
 			spec, err := cc.Spec(ctx)
 			if err != nil {
 				return err
 			}
-			opts := []oci.SpecOpts{
-				coci.WithUser(ec.User),
-				withResetAdditionalGIDs(),
-				coci.WithAdditionalGIDs(ec.User),
+			opts := []coci.SpecOpts{
+				oci.WithUser(ec.User),
+				oci.WithResetAdditionalGIDs(),
+				oci.WithAdditionalGIDs(ec.User),
+			}
+			ci, err := cc.Info(ctx)
+			if err != nil {
+				return err
 			}
 			for _, opt := range opts {
 				if err := opt(ctx, daemon.containerdCli, &ci, spec); err != nil {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -1035,7 +1035,7 @@ func (daemon *Daemon) createSpec(ctx context.Context, c *container.Container) (r
 			Path: "rootfs",
 		}
 		if c.Config.User != "" {
-			opts = append(opts, coci.WithUser(c.Config.User))
+			opts = append(opts, oci.WithUser(c.Config.User))
 		}
 		if c.Config.WorkingDir != "" {
 			opts = append(opts, coci.WithProcessCwd(c.Config.WorkingDir))

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -1,10 +1,21 @@
 package oci // import "github.com/docker/docker/oci"
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
+	"strings"
 
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/mount"
+	coci "github.com/containerd/containerd/oci"
+	"github.com/containerd/continuity/fs"
+	libcontainer "github.com/opencontainers/runc/libcontainer/user"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -74,4 +85,356 @@ func AppendDevicePermissionsFromCgroupRules(devPermissions []specs.LinuxDeviceCg
 		devPermissions = append(devPermissions, dPermissions)
 	}
 	return devPermissions, nil
+}
+
+// WithResetAdditionalGIDs resets additonal GIDs
+// This code is based  nerdctl, under Apache License
+// https://github.com/containerd/nerdctl/blob/2bbd998a1c95e6682120918d9a07a24ccef4f5fb/cmd/nerdctl/run_user.go#L69
+func WithResetAdditionalGIDs() coci.SpecOpts {
+	return func(_ context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+		s.Process.User.AdditionalGids = nil
+		return nil
+	}
+}
+
+// ReadonlyMounts is used by the options which are trying to get user/group
+// information from container's rootfs. Since the option does read operation
+// only, this helper will append ReadOnly mount option to prevent linux kernel
+// from syncing whole filesystem in umount syscall. This also prevents the
+// filesystem to end up in a state with undefined behavior.
+func ReadonlyMounts(mounts []mount.Mount) []mount.Mount {
+	for i, m := range mounts {
+		if m.Type == "overlay" {
+			mounts[i].Options = readonlyOverlay(m.Options)
+		}
+	}
+	if len(mounts) == 1 && mounts[0].Type == "overlay" {
+		mounts[0].Options = append(mounts[0].Options, "ro")
+	}
+	return mounts
+}
+
+func readonlyOverlay(opt []string) []string {
+	out := make([]string, 0, len(opt))
+	upper := ""
+	for _, o := range opt {
+		if strings.HasPrefix(o, "upperdir=") {
+			upper = strings.TrimPrefix(o, "upperdir=")
+		} else if !strings.HasPrefix(o, "workdir=") {
+			out = append(out, o)
+		}
+	}
+	if upper != "" {
+		for i, o := range out {
+			if strings.HasPrefix(o, "lowerdir=") {
+				out[i] = "lowerdir=" + upper + ":" + strings.TrimPrefix(o, "lowerdir=")
+			}
+		}
+	}
+	return out
+}
+
+func isRootfsAbs(root string) bool {
+	return filepath.IsAbs(root)
+}
+
+// setProcess sets Process to empty if unset
+func setProcess(s *coci.Spec) {
+	if s.Process == nil {
+		s.Process = &specs.Process{}
+	}
+}
+
+func getSupplementalGroupsFromPath(root string, filter func(libcontainer.Group) bool) ([]uint32, error) {
+	gpath, err := fs.RootPath(root, "/etc/group")
+	if err != nil {
+		return []uint32{}, err
+	}
+	groups, err := libcontainer.ParseGroupFileFilter(gpath, filter)
+	if err != nil {
+		return []uint32{}, err
+	}
+	if len(groups) == 0 {
+		// if there are no additional groups; just return an empty set
+		return []uint32{}, nil
+	}
+	addlGids := []uint32{}
+	for _, grp := range groups {
+		addlGids = append(addlGids, uint32(grp.Gid))
+	}
+	return addlGids, nil
+}
+
+// WithUserID sets the correct UID and GID for the container based
+// on the image's /etc/passwd contents. If /etc/passwd does not exist,
+// or uid is not found in /etc/passwd, it sets the requested uid,
+// additionally sets the gid to 0, and does not return an error.
+func withUserID(uid uint32) coci.SpecOpts {
+	return func(ctx context.Context, client coci.Client, c *containers.Container, s *coci.Spec) (err error) {
+		setProcess(s)
+		if c.Snapshotter == "" && c.SnapshotKey == "" {
+			if !isRootfsAbs(s.Root.Path) {
+				return errors.New("rootfs absolute path is required")
+			}
+			user, err := coci.UserFromPath(s.Root.Path, func(u libcontainer.User) bool {
+				return u.Uid == int(uid)
+			})
+			if err != nil {
+				if os.IsNotExist(err) || err == coci.ErrNoUsersFound {
+					s.Process.User.UID, s.Process.User.GID = uid, 0
+					return nil
+				}
+				return err
+			}
+			s.Process.User.UID, s.Process.User.GID = uint32(user.Uid), uint32(user.Gid)
+			return nil
+
+		}
+		if c.Snapshotter == "" {
+			return errors.New("no snapshotter set for container")
+		}
+		if c.SnapshotKey == "" {
+			return errors.New("rootfs snapshot not created for container")
+		}
+		snapshotter := client.SnapshotService(c.Snapshotter)
+		mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
+		if err != nil {
+			return err
+		}
+
+		mounts = ReadonlyMounts(mounts)
+		return mount.WithTempMount(ctx, mounts, func(root string) error {
+			user, err := coci.UserFromPath(root, func(u libcontainer.User) bool {
+				return u.Uid == int(uid)
+			})
+			if err != nil {
+				if os.IsNotExist(err) || err == coci.ErrNoUsersFound {
+					s.Process.User.UID, s.Process.User.GID = uid, 0
+					return nil
+				}
+				return err
+			}
+			s.Process.User.UID, s.Process.User.GID = uint32(user.Uid), uint32(user.Gid)
+			return nil
+		})
+	}
+}
+
+// WithUsername sets the correct UID and GID for the container
+// based on the image's /etc/passwd contents. If /etc/passwd
+// does not exist, or the username is not found in /etc/passwd,
+// it returns error. On Windows this sets the username as provided,
+// the operating system will validate the user when going to run
+// the container.
+func withUsername(username string) coci.SpecOpts {
+	return func(ctx context.Context, client coci.Client, c *containers.Container, s *coci.Spec) (err error) {
+		setProcess(s)
+		if s.Linux != nil {
+			if c.Snapshotter == "" && c.SnapshotKey == "" {
+				if !isRootfsAbs(s.Root.Path) {
+					return errors.New("rootfs absolute path is required")
+				}
+				user, err := coci.UserFromPath(s.Root.Path, func(u libcontainer.User) bool {
+					return u.Name == username
+				})
+				if err != nil {
+					return err
+				}
+				s.Process.User.UID, s.Process.User.GID = uint32(user.Uid), uint32(user.Gid)
+				return nil
+			}
+			if c.Snapshotter == "" {
+				return errors.New("no snapshotter set for container")
+			}
+			if c.SnapshotKey == "" {
+				return errors.New("rootfs snapshot not created for container")
+			}
+			snapshotter := client.SnapshotService(c.Snapshotter)
+			mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
+			if err != nil {
+				return err
+			}
+
+			mounts = ReadonlyMounts(mounts)
+			return mount.WithTempMount(ctx, mounts, func(root string) error {
+				user, err := coci.UserFromPath(root, func(u libcontainer.User) bool {
+					return u.Name == username
+				})
+				if err != nil {
+					return err
+				}
+				s.Process.User.UID, s.Process.User.GID = uint32(user.Uid), uint32(user.Gid)
+				return nil
+			})
+		} else if s.Windows != nil {
+			s.Process.User.Username = username
+		} else {
+			return errors.New("spec does not contain Linux or Windows section")
+		}
+		return nil
+	}
+}
+
+// WithUser sets the user to be used within the container.
+// It accepts a valid user string in OCI Image Spec v1.0.0:
+//   user, uid, user:group, uid:gid, uid:group, user:gid
+func WithUser(userstr string) coci.SpecOpts {
+	return func(ctx context.Context, client coci.Client, c *containers.Container, s *coci.Spec) error {
+		// For LCOW it's a bit harder to confirm that the user actually exists on the host as a rootfs isn't
+		// mounted on the host and shared into the guest, but rather the rootfs is constructed entirely in the
+		// guest itself. To accommodate this, a spot to place the user string provided by a client as-is is needed.
+		// The `Username` field on the runtime spec is marked by Platform as only for Windows, and in this case it
+		// *is* being set on a Windows host at least, but will be used as a temporary holding spot until the guest
+		// can use the string to perform these same operations to grab the uid:gid inside.
+		if s.Windows != nil && s.Linux != nil {
+			s.Process.User.Username = userstr
+			return nil
+		}
+
+		parts := strings.Split(userstr, ":")
+		switch len(parts) {
+		case 1:
+			v, err := strconv.Atoi(parts[0])
+			if err != nil {
+				// if we cannot parse as a uint they try to see if it is a username
+				return withUsername(userstr)(ctx, client, c, s)
+			}
+			return withUserID(uint32(v))(ctx, client, c, s)
+		case 2:
+			var (
+				username  string
+				groupname string
+			)
+			var uid, gid uint32
+			v, err := strconv.Atoi(parts[0])
+			if err != nil {
+				username = parts[0]
+			} else {
+				uid = uint32(v)
+			}
+			if v, err = strconv.Atoi(parts[1]); err != nil {
+				groupname = parts[1]
+			} else {
+				gid = uint32(v)
+			}
+			if username == "" && groupname == "" {
+				s.Process.User.UID, s.Process.User.GID = uid, gid
+				return nil
+			}
+			f := func(root string) error {
+				if username != "" {
+					user, err := coci.UserFromPath(root, func(u libcontainer.User) bool {
+						return u.Name == username
+					})
+					if err != nil {
+						return err
+					}
+					uid = uint32(user.Uid)
+				}
+				if groupname != "" {
+					gid, err = coci.GIDFromPath(root, func(g libcontainer.Group) bool {
+						return g.Name == groupname
+					})
+					if err != nil {
+						return err
+					}
+				}
+				s.Process.User.UID, s.Process.User.GID = uid, gid
+				return nil
+			}
+			if c.Snapshotter == "" && c.SnapshotKey == "" {
+				if !isRootfsAbs(s.Root.Path) {
+					return errors.New("rootfs absolute path is required")
+				}
+				return f(s.Root.Path)
+			}
+			if c.Snapshotter == "" {
+				return errors.New("no snapshotter set for container")
+			}
+			if c.SnapshotKey == "" {
+				return errors.New("rootfs snapshot not created for container")
+			}
+			snapshotter := client.SnapshotService(c.Snapshotter)
+			mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
+			if err != nil {
+				return err
+			}
+
+			mounts = ReadonlyMounts(mounts)
+			return mount.WithTempMount(ctx, mounts, f)
+		default:
+			return fmt.Errorf("invalid USER value %s", userstr)
+		}
+	}
+}
+
+// WithAdditionalGIDs sets the OCI spec's additionalGids array to any additional groups listed
+// for a particular user in the /etc/groups file of the image's root filesystem
+// The passed in user can be either a uid or a username.
+func WithAdditionalGIDs(userstr string) coci.SpecOpts {
+	return func(ctx context.Context, client coci.Client, c *containers.Container, s *coci.Spec) (err error) {
+		// For LCOW or on Darwin additional GID's not supported
+		if s.Windows != nil || runtime.GOOS == "darwin" {
+			return nil
+		}
+		setProcess(s)
+		setAdditionalGids := func(root string) error {
+			var username string
+			uid, err := strconv.Atoi(userstr)
+			if err == nil {
+				user, err := coci.UserFromPath(root, func(u libcontainer.User) bool {
+					return u.Uid == uid
+				})
+				if err != nil {
+					if os.IsNotExist(err) || err == coci.ErrNoUsersFound {
+						return nil
+					}
+					return err
+				}
+				username = user.Name
+			} else {
+				username = userstr
+			}
+			gids, err := getSupplementalGroupsFromPath(root, func(g libcontainer.Group) bool {
+				// we only want supplemental groups
+				if g.Name == username {
+					return false
+				}
+				for _, entry := range g.List {
+					if entry == username {
+						return true
+					}
+				}
+				return false
+			})
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return err
+			}
+			s.Process.User.AdditionalGids = gids
+			return nil
+		}
+		if c.Snapshotter == "" && c.SnapshotKey == "" {
+			if !isRootfsAbs(s.Root.Path) {
+				return errors.New("rootfs absolute path is required")
+			}
+			return setAdditionalGids(s.Root.Path)
+		}
+		if c.Snapshotter == "" {
+			return errors.New("no snapshotter set for container")
+		}
+		if c.SnapshotKey == "" {
+			return errors.New("rootfs snapshot not created for container")
+		}
+		snapshotter := client.SnapshotService(c.Snapshotter)
+		mounts, err := snapshotter.Mounts(ctx, c.SnapshotKey)
+		if err != nil {
+			return err
+		}
+
+		mounts = ReadonlyMounts(mounts)
+		return mount.WithTempMount(ctx, mounts, setAdditionalGids)
+	}
 }


### PR DESCRIPTION
Mounting the same directory twice with overlayfs will put the mounts in an undefined behavior. We need to make sure that the mounts we do are read-only.

**- What I did**

Took the code from containerd and added the `ReadonlyMounts` method to make sure that we are mounting in read-only mode.

**- How I did it**

* copy/paste c8d code from https://github.com/containerd/containerd/blob/main/oci/spec_opts.go
* https://github.com/moby/buildkit/pull/1100

**- How to verify it**

Run `docker run -it --user 1000 docker/dev-environments-go:stable-1` and then, in a different terminal, exec into that container, try to create a file, it should work and not fail with `No such file or directory`.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/190417020-b809b9d3-be0d-408c-ba2b-0db0f84c1837.png)

