### PR TITLE
consider digest and ignore tag when both are set

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -139,13 +139,8 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (img co
 
 	is := i.client.ImageService()
 
-	namedRef, ok := parsed.(reference.Named)
-	if !ok {
-		digested, ok := parsed.(reference.Digested)
-		if !ok {
-			return containerdimages.Image{}, errdefs.InvalidParameter(errors.New("bad reference"))
-		}
-
+	digested, ok := parsed.(reference.Digested)
+	if ok {
 		imgs, err := is.List(ctx, fmt.Sprintf("target.digest==%s", digested.Digest()))
 		if err != nil {
 			return containerdimages.Image{}, errors.Wrap(err, "failed to lookup digest")
@@ -157,6 +152,7 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (img co
 		return imgs[0], nil
 	}
 
+	namedRef, ok := parsed.(reference.Named)
 	namedRef = reference.TagNameOnly(namedRef)
 
 	// If the identifier could be a short ID, attempt to match


### PR DESCRIPTION
**- What I did**
This align with API Client: 
when image both has tag and digest, only digest is considered and tag is dropped
see https://github.com/rumpl/moby/blob/master/client/image_pull.go#L55-L63

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/191765495-a42587f8-632e-46f5-bc57-5a6a9385f14e.png)
