### PR TITLE
daemon/c8d: Limit concurrent downloads/uploads

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -59,6 +59,11 @@ func (i *ImageService) PullImage(ctx context.Context, image, tagOrDigest string,
 	opts = append(opts, containerd.WithImageHandler(h))
 	opts = i.applySnapshotterOpts(opts, ref)
 
+	if i.limits.MaxConcurrentDownloads > 0 {
+		// TODO(vvoland): use the i.downloadLimiter directly
+		opts = append(opts, containerd.WithMaxConcurrentDownloads(i.limits.MaxConcurrentDownloads))
+	}
+
 	out := streamformatter.NewJSONProgressOutput(outStream, false)
 	finishProgress := showProgress(ctx, jobs, out, pullProgress(i.client.ContentStore(), true))
 	defer finishProgress()

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -15,7 +15,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 )
 
 // PushImage initiates a push operation on the repository named localName.
@@ -92,8 +91,7 @@ func (i *ImageService) PushImage(ctx context.Context, image, tag string, metaHea
 		}
 	}()
 
-	var limiter *semaphore.Weighted = nil // TODO: Respect max concurrent downloads/uploads
-	pusher := newLazyPusher(store, resolver, jobs, limiter, limiter)
+	pusher := newLazyPusher(store, resolver, jobs, i.downloadLimiter, i.uploadLimiter)
 
 	leasedCtx, release, err := i.client.WithLease(ctx)
 	if err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1020,7 +1020,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		if err := configureKernelSecuritySupport(config, driverName); err != nil {
 			return nil, err
 		}
-		d.imageService = ctrd.NewService(d.containerdCli, d.containers, driverName, d, d.registryService)
+		limits := ctrd.Limits{
+			MaxConcurrentDownloads: config.MaxConcurrentDownloads,
+			MaxConcurrentUploads:   config.MaxConcurrentUploads,
+		}
+		d.imageService = ctrd.NewService(d.containerdCli, limits, d.containers, driverName, d, d.registryService)
 	} else {
 		layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{
 			Root:                      config.Root,
@@ -1121,10 +1125,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		// if migration is called from daemon/images. layerStore might move as well.
 		d.imageService = images.NewImageService(imgSvcConfig)
 
-		logrus.Debugf("Max Concurrent Downloads: %d", imgSvcConfig.MaxConcurrentDownloads)
-		logrus.Debugf("Max Concurrent Uploads: %d", imgSvcConfig.MaxConcurrentUploads)
 		logrus.Debugf("Max Download Attempts: %d", imgSvcConfig.MaxDownloadAttempts)
 	}
+	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
+	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
 
 	go d.execCommandGC()
 


### PR DESCRIPTION
Respect the maximum concurrent downloads/upload daemon configuration.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

