### PR TITLE
c8d/export: Fix temporary image being deleted too early

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -73,27 +73,34 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 	}
 
 	for _, imageRef := range names {
-		var err error
-		opts, err = i.appendImageForExport(ctx, opts, imageRef)
+		newOpt, tmpImage, err := i.optForImageExport(ctx, imageRef)
+		if tmpImage != nil {
+			defer i.client.ImageService().Delete(ctx, tmpImage.Name, containerdimages.SynchronousDelete())
+		}
 		if err != nil {
 			return err
+		}
+		if newOpt != nil {
+			opts = append(opts, newOpt)
 		}
 	}
 
 	return i.client.Export(ctx, outStream, opts...)
 }
 
-func (i *ImageService) appendImageForExport(ctx context.Context, opts []archive.ExportOpt, name string) ([]archive.ExportOpt, error) {
+// optForImageExport returns an archive.ExportOpt that should include the image
+// with the provided name in the output archive.
+func (i *ImageService) optForImageExport(ctx context.Context, name string) (archive.ExportOpt, *containerdimages.Image, error) {
 	ref, err := reference.ParseDockerRef(name)
 	if err != nil {
-		return opts, err
+		return nil, nil, err
 	}
 
 	is := i.client.ImageService()
 
 	img, err := is.Get(ctx, ref.String())
 	if err != nil {
-		return opts, err
+		return nil, nil, err
 	}
 
 	store := i.client.ContentStore()
@@ -101,7 +108,7 @@ func (i *ImageService) appendImageForExport(ctx context.Context, opts []archive.
 	if containerdimages.IsIndexType(img.Target.MediaType) {
 		children, err := containerdimages.Children(ctx, store, img.Target)
 		if err != nil {
-			return opts, err
+			return nil, nil, err
 		}
 
 		// Check which platform manifests we have blobs for.
@@ -115,7 +122,7 @@ func (i *ImageService) appendImageForExport(ctx context.Context, opts []archive.
 					logrus.WithField("digest", child.Digest.String()).Debug("missing blob, not exporting")
 					continue
 				} else if err != nil {
-					return opts, err
+					return nil, nil, err
 				}
 				presentPlatforms = append(presentPlatforms, *child.Platform)
 			}
@@ -123,7 +130,7 @@ func (i *ImageService) appendImageForExport(ctx context.Context, opts []archive.
 
 		// If we have all the manifests, just export the original index.
 		if len(missingPlatforms) == 0 {
-			return append(opts, archive.WithImage(is, img.Name)), nil
+			return archive.WithImage(is, img.Name), nil, nil
 		}
 
 		// Create a new manifest which contains only the manifests we have in store.
@@ -132,11 +139,10 @@ func (i *ImageService) appendImageForExport(ctx context.Context, opts []archive.
 		newImg, err := converter.Convert(ctx, i.client, targetRef, srcRef,
 			converter.WithPlatform(platforms.Any(presentPlatforms...)))
 		if err != nil {
-			return opts, err
+			return nil, newImg, err
 		}
-		defer i.client.ImageService().Delete(ctx, newImg.Name, containerdimages.SynchronousDelete())
-		return append(opts, archive.WithManifest(newImg.Target, srcRef)), nil
+		return archive.WithManifest(newImg.Target, srcRef), newImg, nil
 	}
 
-	return append(opts, archive.WithImage(is, img.Name)), nil
+	return archive.WithImage(is, img.Name), nil, nil
 }

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/pkg/containerfs"
+	"github.com/google/uuid"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -135,7 +136,7 @@ func (i *ImageService) optForImageExport(ctx context.Context, name string) (arch
 
 		// Create a new manifest which contains only the manifests we have in store.
 		srcRef := ref.String()
-		targetRef := srcRef + "-tmp-export"
+		targetRef := srcRef + "-tmp-export" + uuid.NewString()
 		newImg, err := converter.Convert(ctx, i.client, targetRef, srcRef,
 			converter.WithPlatform(platforms.Any(presentPlatforms...)))
 		if err != nil {


### PR DESCRIPTION
The image was scheduled for deletion before the actual export was started.
For bigger images this resulted in the output archive being incomplete, because the content is usually deleted faster than the whole image is exported to an archive.

Also made the temporary image name unique by adding an uuid, just to avoid breaking the export if concurrent exports are taking place.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

