### PR TITLE
c8d/builder: store untagged images

### DIFF
--- a/builder/builder-next/control/control.go
+++ b/builder/builder-next/control/control.go
@@ -284,8 +284,11 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 			if err != nil {
 				return nil, err
 			}
+			if req.ExporterAttrs == nil {
+				req.ExporterAttrs = make(map[string]string)
+			}
 
-			if req.ExporterAttrs != nil {
+			if req.ExporterAttrs["name"] != "" {
 				reposAndTags, err := sanitizeRepoAndTags(strings.Split(req.ExporterAttrs["name"], ","))
 				if err != nil {
 					return nil, err
@@ -296,7 +299,10 @@ func (c *Controller) Solve(ctx context.Context, req *controlapi.SolveRequest) (*
 				}
 
 				req.ExporterAttrs["name"] = strings.Join(names, ",")
-				req.ExporterAttrs["unpack"] = "true"
+			}
+			req.ExporterAttrs["unpack"] = "true"
+			if _, has := req.ExporterAttrs["dangling-name-prefix"]; !has {
+				req.ExporterAttrs["dangling-name-prefix"] = "dangling"
 			}
 		} else {
 			exp, err = w.Exporter(req.Exporter, c.opt.SessionManager)

--- a/builder/builder-next/exporter/containerimage/export.go
+++ b/builder/builder-next/exporter/containerimage/export.go
@@ -34,6 +34,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const ImagePrefixDangling = "dangling"
+
 const (
 	keyImageName        = "name"
 	keyPush             = "push"

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/distribution/reference"
 	containertypes "github.com/docker/docker/api/types/container"
 	imagetype "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/builder/builder-next/exporter/containerimage"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
@@ -234,4 +235,9 @@ func (i *ImageService) presentChildrenHandler() containerdimages.HandlerFunc {
 
 		return containerdimages.Children(ctx, store, desc)
 	}
+}
+
+func isDanglingImage(img containerd.Image) bool {
+	danglingName := containerimage.ImagePrefixDangling + "@" + img.Target().Digest.String()
+	return img.Name() == danglingName
 }

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -95,11 +95,19 @@ func (i *ImageService) Images(ctx context.Context, opts types.ImageListOptions) 
 			return nil, err
 		}
 
-		familiarName := reference.FamiliarString(ref)
+		var repoDigests, repoTags []string
+		if isDanglingImage(img) {
+			repoTags = []string{"<none>:<none>"}
+			repoDigests = []string{"<none>@<none>"}
+		} else {
+			familiarName := reference.FamiliarString(ref)
+			repoTags = []string{familiarName}
+			repoDigests = []string{familiarName + "@" + img.Target().Digest.String()} // "hello-world@sha256:bfea6278a0a267fad2634554f4f0c6f31981eea41c553fdf5a83e95a41d40c38"
+		}
 
 		ret = append(ret, &types.ImageSummary{
-			RepoDigests: []string{familiarName + "@" + img.Target().Digest.String()}, // "hello-world@sha256:bfea6278a0a267fad2634554f4f0c6f31981eea41c553fdf5a83e95a41d40c38"},
-			RepoTags:    []string{familiarName},
+			RepoDigests: repoDigests,
+			RepoTags:    repoTags,
 			Containers:  -1,
 			ParentID:    "",
 			SharedSize:  -1,


### PR DESCRIPTION
Requires:
- #99

Set the `dangling-name-prefix` attribute to `dangling` to store images that are built without a tag.
Image list was also adjusted to account for the dangling images and they are shown like in the current Docker.