### PR TITLE
Handle dangling images in prune/tag

### DIFF
--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -49,5 +49,14 @@ func (i *ImageService) TagImageWithReference(ctx context.Context, imageID image.
 	is := i.client.ImageService()
 	_, err = is.Create(ctx, img)
 
+	if err == nil {
+		if isDanglingImage(ci) {
+			delErr := is.Delete(ctx, ci.Name())
+			if delErr != nil {
+				logrus.WithField("name", ci.Name()).Debug("failed to remove dangling image")
+			}
+		}
+	}
+
 	return err
 }


### PR DESCRIPTION
Requires:
- https://github.com/rumpl/moby/pull/100

Changes:
- `docker image prune` deletes dangling (images which were built without a tag) images
- `docker tag <dangling hash> <new-tag>` will remove the old "dangling" image so `docker image ls` will show only the image with a <new-tag>