### PR TITLE
daemon/images: Don't unset BaseFS

### DIFF
--- a/daemon/images/mount.go
+++ b/daemon/images/mount.go
@@ -22,7 +22,7 @@ func (i *ImageService) Mount(ctx context.Context, container *container.Container
 	}
 	logrus.WithField("container", container.ID).Debugf("container mounted via layerStore: %v", dir)
 
-	if container.BaseFS != dir {
+	if container.BaseFS != "" && container.BaseFS != dir {
 		// The mount path reported by the graph driver should always be trusted on Windows, since the
 		// volume path for a given mounted layer may change over time.  This should only be an error
 		// on non-Windows operating systems.
@@ -45,7 +45,6 @@ func (i *ImageService) Unmount(ctx context.Context, container *container.Contain
 		logrus.WithField("container", container.ID).WithError(err).Error("error unmounting container")
 		return err
 	}
-	container.BaseFS = ""
 
 	return nil
 }


### PR DESCRIPTION
Relates to:
- https://github.com/rumpl/moby/pull/65

#65 did introduce unsetting the BaseFS, which is actually incorrect behaviour: https://github.com/moby/moby/pull/44075#discussion_r968123380 and breaks `docker run` when running with the old graphdriver instead of c8d snapshotter.

This reverts part of #65, so when upstreaming, this needs to be squashed.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

