### PR TITLE
c8d/daemon: Allow restore containers

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	Healthcheck     *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
 	ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
 	Image           string              // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Platform        v1.Platform         `json:"-"`
+	Platform        v1.Platform         `json:",omitempty"`
 	Volumes         map[string]struct{} // List of volumes (mounts) used for the container
 	WorkingDir      string              // Current directory (PWD) in the command will be launched
 	Entrypoint      strslice.StrSlice   // Entrypoint to run when starting the container

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -8,7 +8,6 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/url"
 	"os"
@@ -230,12 +229,6 @@ func (daemon *Daemon) restore() error {
 	dir, err := os.ReadDir(daemon.repository)
 	if err != nil {
 		return err
-	}
-
-	// Restoring containers after a restart is not yet supported
-	// when using the containerd content store.
-	if daemon.UsesSnapshotter() {
-		dir = []fs.DirEntry{}
 	}
 
 	// parallelLimit is the maximum number of parallel startup jobs that we


### PR DESCRIPTION
Re-enable the containers restore mechanism after daemon restart.
This seems to work correctly after bringing up Cory's libcontainerd related changes from the upstream.