### PR TITLE
Fix linter errors after rebase

### DIFF
--- a/builder/builder-next/worker/containerdworker.go
+++ b/builder/builder-next/worker/containerdworker.go
@@ -108,7 +108,6 @@ func (w *ContainerdWorker) Exporter(name string, sm *session.Manager) (exporter.
 			RegistryHosts:  w.baseWorker.WorkerOpt.RegistryHosts,
 			LeaseManager:   w.baseWorker.WorkerOpt.LeaseManager,
 		})
-		return w.baseWorker.Exporter(client.ExporterImage, sm)
 	default:
 		return w.baseWorker.Exporter(name, sm)
 	}

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -462,7 +462,7 @@ func TestRunWithBuildArgs(t *testing.T) {
 	mockBackend.makeImageCacheFunc = func(_ []string) builder.ImageCache {
 		return imageCache
 	}
-	b.imageProber = newImageProber(nil, mockBackend, nil, false)
+	b.imageProber = newImageProber(context.TODO(), mockBackend, nil, false)
 	mockBackend.getImageFunc = func(_ string) (builder.Image, builder.ROLayer, error) {
 		return &mockImage{
 			id:     "abcdef",
@@ -528,7 +528,7 @@ func TestRunIgnoresHealthcheck(t *testing.T) {
 	mockBackend.makeImageCacheFunc = func(_ []string) builder.ImageCache {
 		return imageCache
 	}
-	b.imageProber = newImageProber(nil, mockBackend, nil, false)
+	b.imageProber = newImageProber(context.TODO(), mockBackend, nil, false)
 	mockBackend.getImageFunc = func(_ string) (builder.Image, builder.ROLayer, error) {
 		return &mockImage{
 			id:     "abcdef",

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -157,7 +157,7 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string, platfor
 		return imgs[0], nil
 	}
 
-	namedRef, ok := parsed.(reference.Named)
+	namedRef := parsed.(reference.Named)
 	namedRef = reference.TagNameOnly(namedRef)
 
 	// If the identifier could be a short ID, attempt to match

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -69,6 +69,9 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 
 	target := baseImg.Target()
 	b, err := content.ReadBlob(ctx, contentStore, target)
+	if err != nil {
+		return "", err
+	}
 	var ocimanifest ocispec.Manifest
 	if err := json.Unmarshal(b, &ocimanifest); err != nil {
 		return "", err

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -134,7 +134,7 @@ func (i *ImageService) ImportImage(ctx context.Context, src string, repository s
 
 	// FIXME: connect with commit code and call refstore directly
 	if newRef != nil {
-		if err := i.TagImageWithReference(nil, id, newRef); err != nil {
+		if err := i.TagImageWithReference(ctx, id, newRef); err != nil {
 			return err
 		}
 	}

--- a/daemon/images/image_tag.go
+++ b/daemon/images/image_tag.go
@@ -26,7 +26,7 @@ func (i *ImageService) TagImage(ctx context.Context, imageName, repository, tag 
 		}
 	}
 
-	err = i.TagImageWithReference(nil, img.ID(), newTag)
+	err = i.TagImageWithReference(ctx, img.ID(), newTag)
 	return reference.FamiliarString(newTag), err
 }
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -735,9 +735,8 @@ func WithCommonOptions(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			if err := c.SetupWorkingDirectory(daemon.idMapping.RootPair()); err != nil {
 				return err
 			}
-		} else {
-
 		}
+
 		cwd := c.Config.WorkingDir
 		if len(cwd) == 0 {
 			cwd = "/"

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/mount"
-	coci "github.com/containerd/containerd/oci"
 	"github.com/containerd/continuity/fs"
+
+	coci "github.com/containerd/containerd/oci"
 	libcontainer "github.com/opencontainers/runc/libcontainer/user"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -87,7 +88,7 @@ func AppendDevicePermissionsFromCgroupRules(devPermissions []specs.LinuxDeviceCg
 	return devPermissions, nil
 }
 
-// WithResetAdditionalGIDs resets additonal GIDs
+// WithResetAdditionalGIDs resets additional GIDs
 // This code is based  nerdctl, under Apache License
 // https://github.com/containerd/nerdctl/blob/2bbd998a1c95e6682120918d9a07a24ccef4f5fb/cmd/nerdctl/run_user.go#L69
 func WithResetAdditionalGIDs() coci.SpecOpts {
@@ -277,7 +278,7 @@ func withUsername(username string) coci.SpecOpts {
 
 // WithUser sets the user to be used within the container.
 // It accepts a valid user string in OCI Image Spec v1.0.0:
-//   user, uid, user:group, uid:gid, uid:group, user:gid
+// user, uid, user:group, uid:gid, uid:group, user:gid
 func WithUser(userstr string) coci.SpecOpts {
 	return func(ctx context.Context, client coci.Client, c *containers.Container, s *coci.Spec) error {
 		// For LCOW it's a bit harder to confirm that the user actually exists on the host as a rootfs isn't


### PR DESCRIPTION
Fix linter errors that were made in our fork's and were detected after rebase on upstream master.

Each commit from this PR should be squashed to the corresponding commit it fixes when doing the next rebase or when upstreaming.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

