### PR TITLE
daemon/start: Restore TODO context for container.Start

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -199,8 +199,12 @@ func (daemon *Daemon) containerStart(ctx context.Context, container *container.C
 		return translateContainerdStartErr(container.Path, container.SetExitCode, err)
 	}
 
+	// Passing ctx to ctr.Start caused integration tests
+	// to be stuck in the cleanup phase
+	ctrCtx := context.TODO()
+
 	// TODO(mlaventure): we need to specify checkpoint options here
-	tsk, err := ctr.Start(ctx, checkpointDir,
+	tsk, err := ctr.Start(ctrCtx, checkpointDir,
 		container.StreamConfig.Stdin() != nil || container.Config.Tty,
 		container.InitializeStdio)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

