### PR TITLE
c8d/commit: Fix choosing base manifest, set dangling name, fix errdefs

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -238,6 +238,9 @@ func (i *ImageService) presentChildrenHandler() containerdimages.HandlerFunc {
 }
 
 func isDanglingImage(img containerd.Image) bool {
-	danglingName := containerimage.ImagePrefixDangling + "@" + img.Target().Digest.String()
-	return img.Name() == danglingName
+	return img.Name() == danglingImageName(img.Target().Digest)
+}
+
+func danglingImageName(digest digest.Digest) string {
+	return containerimage.ImagePrefixDangling + "@" + digest.String()
 }

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -199,6 +199,8 @@ func writeContentsForImage(ctx context.Context, snName string, baseImg container
 		Size:      int64(len(newMfstJSON)),
 	}
 
+	cs := baseImg.ContentStore()
+
 	// new manifest should reference the layers and config content
 	labels := map[string]string{
 		"containerd.io/gc.ref.content.0": configDesc.Digest.String(),
@@ -207,7 +209,7 @@ func writeContentsForImage(ctx context.Context, snName string, baseImg container
 		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i+1)] = l.Digest.String()
 	}
 
-	err = content.WriteBlob(ctx, baseImg.ContentStore(), newMfstDesc.Digest.String(), bytes.NewReader(newMfstJSON), newMfstDesc, content.WithLabels(labels))
+	err = content.WriteBlob(ctx, cs, newMfstDesc.Digest.String(), bytes.NewReader(newMfstJSON), newMfstDesc, content.WithLabels(labels))
 	if err != nil {
 		return ocispec.Descriptor{}, "", err
 	}
@@ -216,7 +218,7 @@ func writeContentsForImage(ctx context.Context, snName string, baseImg container
 	labelOpt := content.WithLabels(map[string]string{
 		fmt.Sprintf("containerd.io/gc.ref.snapshot.%s", snName): identity.ChainID(newConfig.RootFS.DiffIDs).String(),
 	})
-	err = content.WriteBlob(ctx, baseImg.ContentStore(), configDesc.Digest.String(), bytes.NewReader(newConfigJSON), configDesc, labelOpt)
+	err = content.WriteBlob(ctx, cs, configDesc.Digest.String(), bytes.NewReader(newConfigJSON), configDesc, labelOpt)
 	if err != nil {
 		return ocispec.Descriptor{}, "", err
 	}

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -100,7 +100,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 
 	// image create
 	img := images.Image{
-		Name:      configDigest.String(),
+		Name:      danglingImageName(configDigest.Digest()),
 		Target:    commitManifestDesc,
 		CreatedAt: time.Now(),
 	}

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
-	cderrdefs "github.com/containerd/containerd/errdefs"
+	cerrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/platforms"
@@ -106,7 +106,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 	}
 
 	if _, err := i.client.ImageService().Update(ctx, img); err != nil {
-		if !errdefs.IsNotFound(err) {
+		if !cerrdefs.IsNotFound(err) {
 			return "", err
 		}
 
@@ -280,7 +280,7 @@ func applyDiffLayer(ctx context.Context, name string, baseImg ocispec.Image, sn 
 	}
 
 	if err = sn.Commit(ctx, name, key); err != nil {
-		if cderrdefs.IsAlreadyExists(err) {
+		if cerrdefs.IsAlreadyExists(err) {
 			return nil
 		}
 		return err


### PR DESCRIPTION
This fixes a few bugs in the `docker commit`.

- Committing an image from container running a non-native platform produced an image for the native platform
- If the base image was manifest list, then the resulting image was missing the parent's rootfs in its layers
- Usage of docker/errdefs instead of containerd/errdefs for checking containerd not found error
- Two images being saved after commit (one with the desired name, and the other one with digest).