### PR TITLE
Fix buildkit tests

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -71,7 +71,7 @@ jobs:
           ./hack/go-mod-prepare.sh
           # FIXME(thaJeztah) temporarily overriding version to use for tests; remove with the next release of buildkit
           # echo "BUILDKIT_REF=$(./hack/buildkit-ref)" >> $GITHUB_ENV
-          echo "BUILDKIT_REF=e27c8e24bb9ee92a170567b8b597201925ae9b8a" >> $GITHUB_ENV
+          echo "BUILDKIT_REF=4febae4f874bd8ef52dec30e988c8fe0bc96b3b9" >> $GITHUB_ENV
         working-directory: moby
       -
         name: Checkout BuildKit ${{ env.BUILDKIT_REF }}


### PR DESCRIPTION
Buildkit tests were failing due to hash mismatch of the url `https://raw.githubusercontent.com/moby/moby/master/README.md`
which was expected to have the content of `https://raw.githubusercontent.com/moby/moby/v20.10.21/README.md`.

Latest tagged version didn't include a fix for this, so let's set a buildkit revision used for tests to one that includes this fix:
https://github.com/moby/buildkit/pull/3281

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

