### PR TITLE
Fix references to default platforms in ps and diff

### DIFF
--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/platforms"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/archive"
@@ -21,15 +19,11 @@ func (i *ImageService) Changes(ctx context.Context, container *container.Contain
 		return nil, uerr
 	}
 
-	cimg, _, uerr := i.getImage(ctx, container.Config.Image, nil)
+	platform := container.Config.Platform
+	baseImg, _, uerr := i.getImage(ctx, container.Config.Image, &platform)
 	if uerr != nil {
 		return nil, uerr
 	}
-	baseImgWithoutPlatform, uerr := i.client.ImageService().Get(ctx, cimg.Name())
-	if uerr != nil {
-		return nil, uerr
-	}
-	baseImg := containerd.NewImageWithPlatform(i.client, baseImgWithoutPlatform, platforms.DefaultStrict())
 	diffIDs, uerr := baseImg.RootFS(ctx)
 	if uerr != nil {
 		return nil, uerr

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -586,7 +586,16 @@ func (daemon *Daemon) refreshImage(ctx context.Context, s *container.Snapshot, f
 	c := s.Container
 	tmpImage := s.Image // keep the original ref if still valid (hasn't changed)
 	if tmpImage != s.ImageID {
-		img, err := daemon.imageService.GetImage(ctx, tmpImage, imagetypes.GetImageOpts{})
+		opts := imagetypes.GetImageOpts{}
+		if daemon.UsesSnapshotter() {
+			ctr, err := daemon.GetContainer(c.ID)
+			if err != nil || ctr == nil {
+				return nil, err
+			}
+			opts.Platform = &ctr.Config.Platform
+		}
+		img, err := daemon.imageService.GetImage(ctx, tmpImage, opts)
+
 		if _, isDNE := err.(images.ErrImageDoesNotExist); err != nil && !isDNE {
 			return nil, err
 		}


### PR DESCRIPTION
- `docker ps` no longer crashes when running a container with non-default platform
- `docker diff` works for containers with non-default platform