### PR TITLE
c8d: Don't panic in UpdateConfig

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -161,7 +161,6 @@ func (i *ImageService) ImageDiskUsage(ctx context.Context) ([]*types.ImageSummar
 //
 // called from reload.go
 func (i *ImageService) UpdateConfig(maxDownloads, maxUploads int) {
-	panic("not implemented")
 }
 
 // GetLayerFolders returns the layer folders from an image RootFS.


### PR DESCRIPTION
We don't support these settings yet and this is used when reload daemon configuration.

This fixes pinata e2e tests which modify the configuration and then reload the daemon.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

