### PR TITLE
daemon: Replace ErrImageDoesNotExist typecheck

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/go-connections/nat"
@@ -595,8 +594,7 @@ func (daemon *Daemon) refreshImage(ctx context.Context, s *container.Snapshot, f
 			opts.Platform = &ctr.Config.Platform
 		}
 		img, err := daemon.imageService.GetImage(ctx, tmpImage, opts)
-
-		if _, isDNE := err.(images.ErrImageDoesNotExist); err != nil && !isDNE {
+		if err != nil && !errdefs.IsNotFound(err) {
 			return nil, err
 		}
 		if err != nil || img.ImageID() != s.ImageID {


### PR DESCRIPTION
Check for generic `errdefs.NotFound` rather than specific error helper struct when checking if the error is caused by the image not being present.
It still works for `ErrImageDoesNotExist` because it implements the NotFound errdefs interface too.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

