### PR TITLE
daemon: Don't set empty platform for GetImageOpts

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -592,7 +592,9 @@ func (daemon *Daemon) refreshImage(ctx context.Context, s *container.Snapshot, f
 			if err != nil || ctr == nil {
 				return nil, err
 			}
-			opts.Platform = &ctr.Config.Platform
+			if ctr.Config.Platform.OS != "" {
+				opts.Platform = &ctr.Config.Platform
+			}
 		}
 		img, err := daemon.imageService.GetImage(ctx, tmpImage, opts)
 


### PR DESCRIPTION
Don't set `GetImageOpts.Platform` to avoid searching for `unknown/unknown` platform in image, when for some reason the `container.Config.Platform` is empty.
This is possible for containers created before `run --platform X` support was added.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

