### PR TITLE
c8d: Change dangling image format

### DIFF
--- a/builder/builder-next/exporter/containerimage/export.go
+++ b/builder/builder-next/exporter/containerimage/export.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const ImagePrefixDangling = "dangling"
+const ImagePrefixDangling = "moby-dangling"
 
 const (
 	keyImageName        = "name"


### PR DESCRIPTION
Upstream PR that introduced dangling images changed the dangling name format from "dangling@hash" to "moby-dangling@hash". 

https://github.com/rumpl/moby/blob/62be425bcc72ba9377f9bde7f6f6978e6036e1b7/daemon/containerd/soft_delete.go#L60

Perform migration to make sure that we keep the state consistent for users who started using containerd integration from our fork once we start shipping the upstream engine instead of fork.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

