### PR TITLE
c8d/exporter: Port save-load from upstream

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -2,21 +2,22 @@ package containerd
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/containerd/containerd"
 	cerrdefs "github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/archive"
-	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/mount"
-	"github.com/containerd/containerd/platforms"
+	cplatforms "github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/container"
-	"github.com/google/uuid"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/pkg/platforms"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -37,6 +38,7 @@ func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Conta
 //
 // TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910
 func (i *ImageService) ExportImage(ctx context.Context, names []string, outStream io.Writer) error {
+	platform := platforms.AllPlatformsWithPreference(cplatforms.Default())
 	opts := []archive.ExportOpt{
 		archive.WithSkipNonDistributableBlobs(),
 
@@ -51,19 +53,48 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 		//  When we export linux/amd64 only, manifest.json will point to linux/amd64.
 		// Note: This is only applicable if importing this archive into non-containerd Docker.
 		// Importing the same archive into containerd, will not restrict the platforms.
-		archive.WithPlatform(allPlatformsWithPreference(platforms.Default())),
+		archive.WithPlatform(platform),
 	}
 
-	for _, imageRef := range names {
-		newOpt, tmpImage, err := i.optForImageExport(ctx, imageRef)
-		if tmpImage != nil {
-			defer i.client.ImageService().Delete(ctx, tmpImage.Name, containerdimages.SynchronousDelete())
-		}
+	ctx, release, err := i.client.WithLease(ctx)
+	if err != nil {
+		return errdefs.System(err)
+	}
+	defer release(ctx)
+
+	for _, name := range names {
+		img, err := i.resolveImage(ctx, name, nil)
 		if err != nil {
 			return err
 		}
-		if newOpt != nil {
-			opts = append(opts, newOpt)
+
+		target := img.Target
+
+		// We may not have locally all the platforms that are specified in the index.
+		// Export only those manifests that we have.
+		// TODO(vvoland): Reconsider this when `--platform` is added.
+		if containerdimages.IsIndexType(target.MediaType) {
+			desc, err := i.getBestDescriptorForExport(ctx, target)
+			if err != nil {
+				return err
+			}
+			target = desc
+		}
+
+		if ref, err := reference.ParseNormalizedNamed(name); err == nil {
+			ref = reference.TagNameOnly(ref)
+			opts = append(opts, archive.WithManifest(target, ref.String()))
+
+			logrus.WithFields(logrus.Fields{
+				"target": target,
+				"name":   ref.String(),
+			}).Debug("export image")
+		} else {
+			opts = append(opts, archive.WithManifest(target))
+
+			logrus.WithFields(logrus.Fields{
+				"target": target,
+			}).Debug("export image without name")
 		}
 	}
 
@@ -76,111 +107,132 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 //
 // TODO(thaJeztah): produce JSON stream progress response and image events; see https://github.com/moby/moby/issues/43910
 func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, outStream io.Writer, quiet bool) error {
-	platform := platforms.All
+	// TODO(vvoland): Allow user to pass platform
+	platform := cplatforms.All
 	imgs, err := i.client.Import(ctx, inTar, containerd.WithImportPlatform(platform))
 
 	if err != nil {
-		// TODO(thaJeztah): remove this log or change to debug once we can; see https://github.com/moby/moby/pull/43822#discussion_r937502405
-		logrus.WithError(err).Warn("failed to import image to containerd")
-		return errors.Wrap(err, "failed to import image")
+		logrus.WithError(err).Debug("failed to import image to containerd")
+		return errdefs.System(err)
 	}
 
+	store := i.client.ContentStore()
+	progress := streamformatter.NewStdoutWriter(outStream)
+
 	for _, img := range imgs {
-		platformImg := containerd.NewImageWithPlatform(i.client, img, platform)
-
-		unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)
+		allPlatforms, err := containerdimages.Platforms(ctx, store, img.Target)
 		if err != nil {
-			// TODO(thaJeztah): remove this log or change to debug once we can; see https://github.com/moby/moby/pull/43822#discussion_r937502405
-			logrus.WithError(err).WithField("image", img.Name).Debug("failed to check if image is unpacked")
-			continue
+			logrus.WithError(err).WithField("image", img.Name).Debug("failed to get image platforms")
+			return errdefs.Unknown(err)
 		}
 
-		if !unpacked {
-			err := platformImg.Unpack(ctx, i.snapshotter)
-			if err != nil {
-				// TODO(thaJeztah): remove this log or change to debug once we can; see https://github.com/moby/moby/pull/43822#discussion_r937502405
-				logrus.WithError(err).WithField("image", img.Name).Warn("failed to unpack image")
-				return errors.Wrap(err, "failed to unpack image")
-			}
+		name := img.Name
+		if named, err := reference.ParseNormalizedNamed(img.Name); err == nil {
+			name = reference.FamiliarName(named)
 		}
+
+		for _, platform := range allPlatforms {
+			logger := logrus.WithFields(logrus.Fields{
+				"platform": platform,
+				"image":    name,
+			})
+			platformImg := containerd.NewImageWithPlatform(i.client, img, cplatforms.OnlyStrict(platform))
+
+			unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)
+			if err != nil {
+				logger.WithError(err).Debug("failed to check if image is unpacked")
+				continue
+			}
+
+			if !unpacked {
+				err = platformImg.Unpack(ctx, i.snapshotter)
+
+				if err != nil {
+					return errdefs.System(err)
+				}
+			}
+			logger.WithField("alreadyUnpacked", unpacked).WithError(err).Debug("unpack")
+		}
+
+		fmt.Fprintf(progress, "Loaded image: %s\n", name)
 	}
 	return nil
 }
 
-// optForImageExport returns an archive.ExportOpt that should include the image
-// with the provided name in the output archive.
-func (i *ImageService) optForImageExport(ctx context.Context, name string) (archive.ExportOpt, *containerdimages.Image, error) {
-	img, err := i.resolveImage(ctx, name, nil)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to resolve image")
-	}
+// getBestDescriptorForExport returns a descriptor which only references content available locally.
+// The returned descriptor can be:
+// - The same index descriptor - if all content is available
+// - Platform specific manifest - if only one manifest from the whole index is available
+// - Reduced index descriptor - if not all, but more than one manifest is available
+//
+// The reduced index descriptor is stored in the content store and may be garbage collected.
+// It's advised to pass a context with a lease that's long enough to cover usage of the blob.
+func (i *ImageService) getBestDescriptorForExport(ctx context.Context, indexDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
+	none := ocispec.Descriptor{}
 
-	ref, err := reference.ParseNamed(img.Name)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to parse image reference")
+	if !containerdimages.IsIndexType(indexDesc.MediaType) {
+		err := fmt.Errorf("index/manifest-list descriptor expected, got: %s", indexDesc.MediaType)
+		return none, errdefs.InvalidParameter(err)
 	}
-
-	is := i.client.ImageService()
 	store := i.client.ContentStore()
-
-	if containerdimages.IsIndexType(img.Target.MediaType) {
-		children, err := containerdimages.Children(ctx, store, img.Target)
-		if err != nil {
-			return nil, nil, err
+	children, err := containerdimages.Children(ctx, store, indexDesc)
+	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return none, errdefs.NotFound(err)
 		}
+		return none, errdefs.System(err)
+	}
 
-		// Check which platform manifests we have blobs for.
-		missingPlatforms := []v1.Platform{}
-		presentPlatforms := []v1.Platform{}
-		for _, child := range children {
-			if containerdimages.IsManifestType(child.MediaType) {
-				_, err := store.ReaderAt(ctx, child)
-				if cerrdefs.IsNotFound(err) {
-					missingPlatforms = append(missingPlatforms, *child.Platform)
-					logrus.WithField("digest", child.Digest.String()).Debug("missing blob, not exporting")
-					continue
-				} else if err != nil {
-					return nil, nil, err
-				}
-				presentPlatforms = append(presentPlatforms, *child.Platform)
+	// Check which platform manifests have all their blobs available.
+	hasMissingManifests := false
+	var presentManifests []ocispec.Descriptor
+	for _, mfst := range children {
+		if containerdimages.IsManifestType(mfst.MediaType) {
+			available, _, _, missing, err := containerdimages.Check(ctx, store, mfst, nil)
+			if err != nil {
+				hasMissingManifests = true
+				logrus.WithField("manifest", mfst.Digest).Warn("failed to check manifest's blob availability, won't export")
+				continue
+			}
+
+			if available && len(missing) == 0 {
+				presentManifests = append(presentManifests, mfst)
+				logrus.WithField("manifest", mfst.Digest).Debug("manifest content present, will export")
+			} else {
+				hasMissingManifests = true
+				logrus.WithFields(logrus.Fields{
+					"manifest": mfst.Digest,
+					"missing":  missing,
+				}).Debug("manifest is missing, won't export")
 			}
 		}
-
-		// If we have all the manifests, just export the original index.
-		if len(missingPlatforms) == 0 {
-			return archive.WithImage(is, img.Name), nil, nil
-		}
-
-		// Create a new manifest which contains only the manifests we have in store.
-		srcRef := ref.String()
-		targetRef := srcRef + "-tmp-export" + uuid.NewString()
-		newImg, err := converter.Convert(ctx, i.client, targetRef, srcRef,
-			converter.WithPlatform(platforms.Any(presentPlatforms...)))
-		if err != nil {
-			return nil, newImg, err
-		}
-		return archive.WithManifest(newImg.Target, srcRef), newImg, nil
 	}
 
-	return archive.WithImage(is, img.Name), nil, nil
-}
-
-// allPlatformsWithPreference will match all platforms but will order
-// platforms matching the preferred matcher first.
-type allPlatformsWithPreferenceMatcher struct {
-	preferred platforms.MatchComparer
-}
-
-func allPlatformsWithPreference(preferred platforms.MatchComparer) platforms.MatchComparer {
-	return allPlatformsWithPreferenceMatcher{
-		preferred: preferred,
+	if !hasMissingManifests || len(children) == 0 {
+		// If we have the full image, or it has no manifests, just export the original index.
+		return indexDesc, nil
+	} else if len(presentManifests) == 1 {
+		// If only one platform is present, export that one manifest.
+		return presentManifests[0], nil
+	} else if len(presentManifests) == 0 {
+		// Return error when none of the image's manifest is present.
+		return none, errdefs.NotFound(fmt.Errorf("none of the manifests is fully present in the content store"))
 	}
-}
 
-func (c allPlatformsWithPreferenceMatcher) Match(_ ocispec.Platform) bool {
-	return true
-}
+	// Create a new index which contains only the manifests we have in store.
+	index := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType:   ocispec.MediaTypeImageIndex,
+		Manifests:   presentManifests,
+		Annotations: indexDesc.Annotations,
+	}
 
-func (c allPlatformsWithPreferenceMatcher) Less(p1, p2 ocispec.Platform) bool {
-	return c.preferred.Less(p1, p2)
+	reducedIndexDesc, err := storeJson(ctx, store, index.MediaType, index, nil)
+	if err != nil {
+		return none, err
+	}
+
+	return reducedIndexDesc, nil
 }

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -1,0 +1,26 @@
+package platforms
+
+import (
+	cplatforms "github.com/containerd/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type allPlatformsWithPreferenceMatcher struct {
+	preferred cplatforms.MatchComparer
+}
+
+// AllPlatformsWithPreference will return a platform matcher that matches all
+// platforms but will order platforms matching the preferred matcher first.
+func AllPlatformsWithPreference(preferred cplatforms.MatchComparer) cplatforms.MatchComparer {
+	return allPlatformsWithPreferenceMatcher{
+		preferred: preferred,
+	}
+}
+
+func (c allPlatformsWithPreferenceMatcher) Match(_ ocispec.Platform) bool {
+	return true
+}
+
+func (c allPlatformsWithPreferenceMatcher) Less(p1, p2 ocispec.Platform) bool {
+	return c.preferred.Less(p1, p2)
+}


### PR DESCRIPTION
- Backport: https://github.com/moby/moby/pull/44833

This doesn't create a temporary containerd image for exported image.

Saved archive will only contain content which is available locally.  In case the saved image is a multi-platform manifest list, the behavior depends on the local availability of the content. This is to be reconsidered when we have the `--platform` option in the CLI.

- If all manifests and their contents, referenced by the manifest list are present, then the manifest-list is exported directly and the ID will be the same.
- If only one platform manifest is present, only that manifest is exported (the image id will change and will be the id of platform-specific manifest, instead of the full manifest list).
- If multiple, but not all, platform manifests are available, a new manifest list will be created which will be a subset of the original manifest list.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

